### PR TITLE
Trim spaces/newlines at beginning/end of verbatim elements

### DIFF
--- a/suse2013/common/trim-verbatim.xsl
+++ b/suse2013/common/trim-verbatim.xsl
@@ -9,15 +9,22 @@
 
 -->
 <xsl:stylesheet version="1.0"
-  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" >
 
 <xsl:template match="programlisting/text()|screen/text()|synopsis/text()">
   <xsl:choose>
-    <xsl:when test="not(preceding-sibling::node()) or preceding-sibling::processing-instruction()[not(preceding-sibling::node())]">
-      <xsl:call-template name="trim-verbatim-whitespace-start"/>
-    </xsl:when>
-    <xsl:when test="not(following-sibling::node()) or following-sibling::processing-instruction()[not(following-sibling::node())]">
-      <xsl:call-template name="trim-verbatim-whitespace-end"/>
+    <xsl:when test="$trim.verbatim = 1">
+      <xsl:choose>
+        <xsl:when test="not(preceding-sibling::node()) or preceding-sibling::processing-instruction()[not(preceding-sibling::node())]">
+          <xsl:call-template name="trim-verbatim-whitespace-start"/>
+        </xsl:when>
+        <xsl:when test="not(following-sibling::node()) or following-sibling::processing-instruction()[not(following-sibling::node())]">
+          <xsl:call-template name="trim-verbatim-whitespace-end"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="self::text()"/>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:when>
     <xsl:otherwise>
       <xsl:value-of select="self::text()"/>
@@ -40,11 +47,20 @@
   <xsl:variable name="first-character" select="substring($input, 1, 1)"/>
   <xsl:variable name="trimmed">
     <xsl:choose>
-      <xsl:when test="$first-character = '&#10;'">
-        <xsl:value-of select="substring($input, 2)"/>
-      </xsl:when>
-      <xsl:when test="(string-length($first-line &gt; 0)) and ($line-length-no-space = 0)">
-        <xsl:value-of select="substring-after($input, '&#10;')"/>
+      <!-- Check if the line contains a break, otherwise we may end up
+           removing spaces from before a <tag> which I am less sure is safe. -->
+      <xsl:when test="contains($input, '&#10;')">
+        <xsl:choose>
+          <xsl:when test="$first-character = '&#10;'">
+            <xsl:value-of select="substring($input, 2)"/>
+          </xsl:when>
+          <xsl:when test="(string-length($first-line &gt; 0)) and ($line-length-no-space = 0)">
+            <xsl:value-of select="substring-after($input, '&#10;')"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$input"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="$input"/>

--- a/suse2013/common/trim-verbatim.xsl
+++ b/suse2013/common/trim-verbatim.xsl
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Purpose:
+     Trim start/end of verbatim areas (screen, programlisting, synopsis)
+
+
+    Author:     Stefan Knorr <sknorr@suse.de>
+    Copyright:  2015
+
+-->
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:template match="programlisting/text()|screen/text()|synopsis/text()">
+  <xsl:choose>
+    <xsl:when test="not(preceding-sibling::node()) or preceding-sibling::processing-instruction()[not(preceding-sibling::node())]">
+      <xsl:call-template name="trim-verbatim-whitespace-start"/>
+    </xsl:when>
+    <xsl:when test="not(following-sibling::node()) or following-sibling::processing-instruction()[not(following-sibling::node())]">
+      <xsl:call-template name="trim-verbatim-whitespace-end"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="self::text()"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<xsl:template name="trim-verbatim-whitespace-start">
+  <!-- Goal: At the start of text, trim lines or that are empty or contain only
+       spaces.
+       Do not trim lines that contain spaces at the beginning and then continue
+       with text. Doing that might destroy some content: e.g. command-line
+       output formatted as a table. -->
+  <xsl:param name="input" select="self::text()"/>
+  <xsl:variable name="first-line" select="substring-before($input, '&#10;')"/>
+  <!-- We could cover many more invisible characters here (en space, em space,
+       zero width space, ...). For simplicity, we focus on space, tab and
+       no-break space here. -->
+  <xsl:variable name="line-length-no-space"  select="string-length(translate($first-line, ' &#9;&#160;', ''))"/>
+  <xsl:variable name="first-character" select="substring($input, 1, 1)"/>
+  <xsl:variable name="trimmed">
+    <xsl:choose>
+      <xsl:when test="$first-character = '&#10;'">
+        <xsl:value-of select="substring($input, 2)"/>
+      </xsl:when>
+      <xsl:when test="(string-length($first-line &gt; 0)) and ($line-length-no-space = 0)">
+        <xsl:value-of select="substring-after($input, '&#10;')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$input"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+  <xsl:choose>
+    <xsl:when test="not($input = $trimmed)">
+      <xsl:call-template name="trim-verbatim-whitespace-start">
+        <xsl:with-param name="input" select="$trimmed"/>
+      </xsl:call-template>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="$trimmed"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<xsl:template name="trim-verbatim-whitespace-end">
+  <!-- Goal: At the end of text, trim whitespace characters.
+       We do this one by one, as that seems the only way possible. -->
+  <xsl:param name="input" select="self::text()"/>
+  <xsl:variable name="last-character" select="substring($input, string-length($input), 1)"/>
+  <xsl:variable name="trimmed">
+    <xsl:choose>
+      <xsl:when test="string-length(translate($last-character, ' &#9;&#10;&#160;', '')) = 0">
+        <xsl:value-of select="substring($input, 1, string-length($input) - 1)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$input"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+
+  <xsl:choose>
+    <xsl:when test="not($input = $trimmed)">
+      <xsl:call-template name="trim-verbatim-whitespace-end">
+        <xsl:with-param name="input" select="$trimmed"/>
+      </xsl:call-template>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="$trimmed"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/suse2013/fo/docbook.xsl
+++ b/suse2013/fo/docbook.xsl
@@ -41,6 +41,7 @@
   <xsl:include href="../common/navigation.xsl"/>
   <xsl:include href="../common/string-replace.xsl"/>
   <xsl:include href="../common/arch-string.xsl"/>
+  <xsl:include href="../common/trim-verbatim.xsl"/>
   <xsl:include href="../common/l10n.xsl"/>
   
   <xsl:include href="autotoc.xsl"/>

--- a/suse2013/fo/param.xsl
+++ b/suse2013/fo/param.xsl
@@ -393,4 +393,7 @@ GERMANY</xsl:param>
   <xsl:text>)</xsl:text>
 </xsl:param>
 
+<!-- Trim away empty lines from the beginning and end of screens -->
+<xsl:param name="trim.verbatim" select="1"/>
+
 </xsl:stylesheet>

--- a/suse2013/xhtml/docbook.xsl
+++ b/suse2013/xhtml/docbook.xsl
@@ -40,6 +40,7 @@
   <xsl:include href="../common/navigation.xsl"/>
   <xsl:include href="../common/string-replace.xsl"/>
   <xsl:include href="../common/arch-string.xsl"/>
+  <xsl:include href="../common/trim-verbatim.xsl"/>
 
   <xsl:include href="param.xsl"/>
   <xsl:include href="create-permalink.xsl"/>

--- a/suse2013/xhtml/param.xsl
+++ b/suse2013/xhtml/param.xsl
@@ -280,4 +280,7 @@ task before
   -->
   <xsl:param name="wrap.img.with.a" select="1"/>
 
+  <!-- Trim away empty lines from the beginning and end of screens -->
+  <xsl:param name="trim.verbatim" select="1"/>
+
 </xsl:stylesheet>


### PR DESCRIPTION
This fixes #53 (and allows authors/scripts to be a bit more lazy when handling screens).