### PR TITLE
Fix #101: introduce a parameter $optimize.plain.text for text output

### DIFF
--- a/suse2013/xhtml/chunk-common.xsl
+++ b/suse2013/xhtml/chunk-common.xsl
@@ -170,30 +170,32 @@
     <xsl:param name="next"/>
     <xsl:param name="nav.context"/>
 
-    <div id="_fixed-header-wrap" class="inactive">
-      <div id="_fixed-header">
-        <xsl:call-template name="breadcrumbs.navigation">
-          <xsl:with-param name="prev" select="$prev"/>
-          <xsl:with-param name="next" select="$next"/>
-          <xsl:with-param name="context">fixed-header</xsl:with-param>
-        </xsl:call-template>
-        <xsl:call-template name="create.header.buttons">
-          <xsl:with-param name="prev" select="$prev"/>
-          <xsl:with-param name="next" select="$next"/>
-        </xsl:call-template>
-        <xsl:call-template name="clearme"/>
-      </div>
-      <xsl:if test="$rootelementname = 'article'">
-      <div class="active-contents bubble">
-        <div class="bubble-container">
-          <div id="_bubble-toc">
-            <xsl:call-template name="bubble-toc"/>
-          </div>
+    <xsl:if test="$generate.fixed.header != 0">
+      <div id="_fixed-header-wrap" class="inactive">
+        <div id="_fixed-header">
+          <xsl:call-template name="breadcrumbs.navigation">
+            <xsl:with-param name="prev" select="$prev"/>
+            <xsl:with-param name="next" select="$next"/>
+            <xsl:with-param name="context">fixed-header</xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="create.header.buttons">
+            <xsl:with-param name="prev" select="$prev"/>
+            <xsl:with-param name="next" select="$next"/>
+          </xsl:call-template>
           <xsl:call-template name="clearme"/>
         </div>
+        <xsl:if test="$generate.bubbletoc != 0 and $rootelementname = 'article'">
+          <div class="active-contents bubble">
+            <div class="bubble-container">
+              <div id="_bubble-toc">
+                <xsl:call-template name="bubble-toc"/>
+              </div>
+              <xsl:call-template name="clearme"/>
+            </div>
+          </div>
+        </xsl:if>
       </div>
-      </xsl:if>
-    </div>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template name="create-find-area">
@@ -264,12 +266,15 @@
       </xsl:choose>
     </xsl:variable>
 
-    <xsl:if test="$rootelementname != 'article'">
+    <xsl:if test="$generate.toolbar != 0 and $rootelementname != 'article'">
       <div id="_toolbar-wrap">
         <div id="_toolbar">
           <xsl:choose>
-            <xsl:when test="$rootnode">
-              <!-- We don't need it for a set -->
+            <!-- We don't need a bubble-toc in the page for set. -->
+            <!-- FIXME: Haven't looked any further, but just testing for
+                 rootnode seems wrong. One might go so far as to say that
+                 $rootnode does not have to be a set. -->
+            <xsl:when test="$generate.bubbletoc = 0 or $rootnode">
               <div id="_toc-area" class="inactive"> </div>
             </xsl:when>
             <xsl:otherwise>
@@ -481,7 +486,7 @@
     <xsl:variable name="setdiff"
       select="ancestor::*[count(. | $ancestorrootnode)
                                 != count($ancestorrootnode)]"/>
-    <xsl:if test="$needs.navig = 'true' and not(self::set)">
+    <xsl:if test="$generate.bottom.navigation != 0 and $needs.navig = 'true' and not(self::set)">
       <div id="_bottom-navigation">
         <xsl:if test="count($next) > 0 and $isnext = 'true'">
           <a class="nav-link">
@@ -577,18 +582,20 @@
         <xsl:call-template name="body.attributes"/>
         <xsl:call-template name="outerelement.class.attribute"/>
         <div id="_outer-wrap">
-          <div id="_white-bg">
-            <div id="_header">
-              <xsl:call-template name="create.header.logo"/>
-              <xsl:call-template name="pickers"/>
-              <xsl:call-template name="breadcrumbs.navigation">
-                <xsl:with-param name="prev" select="$prev"/>
-                <xsl:with-param name="next" select="$next"/>
-              </xsl:call-template>
+          <xsl:if test="$generate.header != 0">
+            <div id="_white-bg">
+              <div id="_header">
+                <xsl:call-template name="create.header.logo"/>
+                <xsl:call-template name="pickers"/>
+                <xsl:call-template name="breadcrumbs.navigation">
+                  <xsl:with-param name="prev" select="$prev"/>
+                  <xsl:with-param name="next" select="$next"/>
+                </xsl:call-template>
 
-              <xsl:call-template name="clearme"/>
+                <xsl:call-template name="clearme"/>
+              </div>
             </div>
-          </div>
+          </xsl:if>
 
           <xsl:call-template name="toolbar-wrap">
             <xsl:with-param name="next" select="$next"/>
@@ -656,9 +663,11 @@
 <!-- ======================================================================= -->
 
   <xsl:template name="bubble-toc">
-    <xsl:call-template name="bubble-toc.inner">
-      <xsl:with-param name="node" select="((ancestor-or-self::book | ancestor-or-self::article)|key('id', $rootid))[last()]"/>
-    </xsl:call-template>
+    <xsl:if test="$generate.bubbletoc != 0">
+      <xsl:call-template name="bubble-toc.inner">
+        <xsl:with-param name="node" select="((ancestor-or-self::book | ancestor-or-self::article)|key('id', $rootid))[last()]"/>
+      </xsl:call-template>
+    </xsl:if>
   </xsl:template>
 
 <!-- ======================================================================= -->

--- a/suse2013/xhtml/docbook.xsl
+++ b/suse2013/xhtml/docbook.xsl
@@ -332,54 +332,54 @@
   <!-- ===================================================== -->
   <xsl:template name="pickers">
     <xsl:if test="$generate.pickers != 0">
-    <div id="_pickers">
-      <div id="_language-picker" class="inactive">
-        <a id="_language-picker-button" href="#">
-          <span class="picker">
-            <xsl:call-template name="gentext">
-              <xsl:with-param name="key">LocalisedLanguageName</xsl:with-param>
-            </xsl:call-template>
-          </span>
-        </a>
-        <div class="bubble-corner active-contents"> </div>
-        <div class="bubble active-contents">
-          <h6>
-            <xsl:call-template name="gentext">
-              <xsl:with-param name="key">selectlanguage</xsl:with-param>
-            </xsl:call-template>
-          </h6>
-          <a class="selected" href="#">
-            <xsl:call-template name="gentext">
-              <xsl:with-param name="key">LocalisedLanguageName</xsl:with-param>
-            </xsl:call-template>
+      <div id="_pickers">
+        <div id="_language-picker" class="inactive">
+          <a id="_language-picker-button" href="#">
+            <span class="picker">
+              <xsl:call-template name="gentext">
+                <xsl:with-param name="key">LocalisedLanguageName</xsl:with-param>
+              </xsl:call-template>
+            </span>
           </a>
+          <div class="bubble-corner active-contents"> </div>
+          <div class="bubble active-contents">
+            <h6>
+              <xsl:call-template name="gentext">
+                <xsl:with-param name="key">selectlanguage</xsl:with-param>
+              </xsl:call-template>
+            </h6>
+            <a class="selected" href="#">
+              <xsl:call-template name="gentext">
+                <xsl:with-param name="key">LocalisedLanguageName</xsl:with-param>
+              </xsl:call-template>
+            </a>
+          </div>
+        </div>
+        <div id="_format-picker" class="inactive">
+          <a id="_format-picker-button" href="#">
+            <span class="picker">Web Page</span>
+          </a>
+          <div class="bubble-corner active-contents"> </div>
+          <div class="bubble active-contents">
+            <h6>
+              <xsl:call-template name="gentext">
+                <xsl:with-param name="key">selectformat</xsl:with-param>
+              </xsl:call-template>
+            </h6>
+            <xsl:call-template name="picker.selection"/>
+            <a href="#">
+              <xsl:call-template name="gentext">
+                <xsl:with-param name="key">formatpdf</xsl:with-param>
+              </xsl:call-template>
+            </a>
+            <a href="#">
+              <xsl:call-template name="gentext">
+                <xsl:with-param name="key">formatepub</xsl:with-param>
+              </xsl:call-template>
+            </a>
+          </div>
         </div>
       </div>
-      <div id="_format-picker" class="inactive">
-        <a id="_format-picker-button" href="#">
-          <span class="picker">Web Page</span>
-        </a>
-        <div class="bubble-corner active-contents"> </div>
-        <div class="bubble active-contents">
-          <h6>
-            <xsl:call-template name="gentext">
-              <xsl:with-param name="key">selectformat</xsl:with-param>
-            </xsl:call-template>
-          </h6>
-          <xsl:call-template name="picker.selection"/>
-          <a href="#">
-            <xsl:call-template name="gentext">
-              <xsl:with-param name="key">formatpdf</xsl:with-param>
-            </xsl:call-template>
-          </a>
-          <a href="#">
-            <xsl:call-template name="gentext">
-              <xsl:with-param name="key">formatepub</xsl:with-param>
-            </xsl:call-template>
-          </a>
-        </div>
-      </div>
-    </div>
     </xsl:if>
   </xsl:template>
 
@@ -397,18 +397,20 @@
   </xsl:template>
 
   <xsl:template name="create.header.logo">
-    <div id="_logo">
-      <xsl:choose>
-        <xsl:when test="$homepage != ''">
-          <a href="{$homepage}">
+    <xsl:if test="$generate.logo != 0">
+      <div id="_logo">
+        <xsl:choose>
+          <xsl:when test="$homepage != ''">
+            <a href="{$homepage}">
+              <img src="{$daps.header.logo}" alt="{$daps.header.logo.alt}"/>
+            </a>
+          </xsl:when>
+          <xsl:otherwise>
             <img src="{$daps.header.logo}" alt="{$daps.header.logo.alt}"/>
-          </a>
-        </xsl:when>
-        <xsl:otherwise>
-          <img src="{$daps.header.logo}" alt="{$daps.header.logo.alt}"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </div>
+          </xsl:otherwise>
+        </xsl:choose>
+      </div>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template name="create.header.buttons">
@@ -454,14 +456,16 @@
         </xsl:call-template>
         <xsl:call-template name="clearme"/>
       </div>
-      <div class="active-contents bubble">
-        <div class="bubble-container">
-          <div id="_bubble-toc">
-            <xsl:call-template name="bubble-toc"/>
+      <xsl:if test="$generate.bubbletoc != 0">
+        <div class="active-contents bubble">
+          <div class="bubble-container">
+            <div id="_bubble-toc">
+              <xsl:call-template name="bubble-toc"/>
+            </div>
+            <xsl:call-template name="clearme"/>
           </div>
-          <xsl:call-template name="clearme"/>
         </div>
-      </div>
+      </xsl:if>
     </div>
   </xsl:template>
 
@@ -470,51 +474,53 @@
     <xsl:param name="next" select="/foo"/>
     <xsl:param name="nav.context"/>
 
-    <div id="_share-print">
-      <xsl:if test="$generate.sharelinks != 0">
-        <div class="online-contents share">
-          <strong><xsl:call-template name="gentext">
-              <xsl:with-param name="key">sharethispage</xsl:with-param>
-            </xsl:call-template>
-          </strong>
-          <!-- &#x2022; = &bull; -->
-          <span class="share-buttons">
-            <span id="_share-fb" class="bottom-button">
-              <xsl:call-template name="gentext">
-                <xsl:with-param name="key">shareviafacebook</xsl:with-param>
+    <xsl:if test="$generate.share.and.print != 0">
+      <div id="_share-print">
+        <xsl:if test="$generate.sharelinks != 0">
+          <div class="online-contents share">
+            <strong><xsl:call-template name="gentext">
+                <xsl:with-param name="key">sharethispage</xsl:with-param>
               </xsl:call-template>
-            </span>
-            <span class="spacer"> &#x2022; </span>
-            <span id="_share-gp" class="bottom-button">
-              <xsl:call-template name="gentext">
-                <xsl:with-param name="key">shareviagoogleplus</xsl:with-param>
-              </xsl:call-template>
-            </span>
-            <span class="spacer"> &#x2022; </span>
-            <span id="_share-tw" class="bottom-button">
-              <xsl:call-template name="gentext">
-                <xsl:with-param name="key">shareviatwitter</xsl:with-param>
-              </xsl:call-template>
-            </span>
-            <xsl:if test="$allow.email.sharelink = 1">
-              <!-- Our email form only works on suse.com pages, thus it is helpful
-                   to be able to disable it separately. -->
-              <span class="spacer"> &#x2022; </span>
-              <span id="_share-mail" class="bottom-button">
+            </strong>
+            <!-- &#x2022; = &bull; -->
+            <span class="share-buttons">
+              <span id="_share-fb" class="bottom-button">
                 <xsl:call-template name="gentext">
-                  <xsl:with-param name="key">shareviaemail</xsl:with-param>
+                  <xsl:with-param name="key">shareviafacebook</xsl:with-param>
                 </xsl:call-template>
               </span>
-            </xsl:if>
-          </span>
-        </div>
-      </xsl:if>
-      <div class="print"><span id="_print-button" class="bottom-button">
-        <xsl:call-template name="gentext">
-          <xsl:with-param name="key">printthispage</xsl:with-param>
-        </xsl:call-template></span></div>
-      <xsl:call-template name="clearme"/>
-    </div>
+              <span class="spacer"> &#x2022; </span>
+              <span id="_share-gp" class="bottom-button">
+                <xsl:call-template name="gentext">
+                  <xsl:with-param name="key">shareviagoogleplus</xsl:with-param>
+                </xsl:call-template>
+              </span>
+              <span class="spacer"> &#x2022; </span>
+              <span id="_share-tw" class="bottom-button">
+                <xsl:call-template name="gentext">
+                  <xsl:with-param name="key">shareviatwitter</xsl:with-param>
+                </xsl:call-template>
+              </span>
+              <xsl:if test="$allow.email.sharelink = 1">
+              <!-- Our email form only works on suse.com pages, thus it is helpful
+                   to be able to disable it separately. -->
+                <span class="spacer"> &#x2022; </span>
+                <span id="_share-mail" class="bottom-button">
+                  <xsl:call-template name="gentext">
+                    <xsl:with-param name="key">shareviaemail</xsl:with-param>
+                  </xsl:call-template>
+                </span>
+              </xsl:if>
+            </span>
+          </div>
+        </xsl:if>
+        <div class="print"><span id="_print-button" class="bottom-button">
+          <xsl:call-template name="gentext">
+            <xsl:with-param name="key">printthispage</xsl:with-param>
+          </xsl:call-template></span></div>
+        <xsl:call-template name="clearme"/>
+      </div>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template name="outerelement.class.attribute">
@@ -575,10 +581,12 @@
           </div>
         </div>
 
-        <xsl:call-template name="fixed-header-wrap">
-          <xsl:with-param name="next" select="$next"/>
-          <xsl:with-param name="prev" select="$prev"/>
-        </xsl:call-template>
+        <xsl:if test="$generate.fixed.header != 0">
+          <xsl:call-template name="fixed-header-wrap">
+            <xsl:with-param name="next" select="$next"/>
+            <xsl:with-param name="prev" select="$prev"/>
+          </xsl:call-template>
+        </xsl:if>
 
         <xsl:call-template name="user.header.content"/>
         <div id="_toc-bubble-wrap"></div>
@@ -670,39 +678,40 @@ else {
           <xsl:text> </xsl:text>
         </xsl:if>
         SUSE</p>
-      <ul>
-        <li>
-          <a href="http://www.suse.com/company/careers/" target="_top">
-            <xsl:call-template name="gentext">
-              <xsl:with-param name="key">susecareers</xsl:with-param>
-            </xsl:call-template>
-          </a>
-        </li>
-        <li>
-          <a href="http://www.suse.com/company/legal/" target="_top">
-            <xsl:call-template name="gentext">
-              <xsl:with-param name="key">suselegal</xsl:with-param>
-            </xsl:call-template>
-          </a>
-        </li>
-        <li>
-          <a href="http://www.suse.com/company/" target="_top">
-            <xsl:call-template name="gentext">
-              <xsl:with-param name="key">suseabout</xsl:with-param>
-            </xsl:call-template>
-          </a>
-        </li>
-        <li>
-          <a href="http://www.suse.com/ContactsOffices/contacts_offices.jsp"
-            target="_top">
-            <xsl:call-template name="gentext">
-              <xsl:with-param name="key">susecontact</xsl:with-param>
-            </xsl:call-template>
-          </a>
-        </li>
-      </ul>
+      <xsl:if test="$generate.footer.links != 0">
+        <ul>
+          <li>
+            <a href="http://www.suse.com/company/careers/" target="_top">
+              <xsl:call-template name="gentext">
+                <xsl:with-param name="key">susecareers</xsl:with-param>
+              </xsl:call-template>
+            </a>
+          </li>
+          <li>
+            <a href="http://www.suse.com/company/legal/" target="_top">
+              <xsl:call-template name="gentext">
+                <xsl:with-param name="key">suselegal</xsl:with-param>
+              </xsl:call-template>
+            </a>
+          </li>
+          <li>
+            <a href="http://www.suse.com/company/" target="_top">
+              <xsl:call-template name="gentext">
+                <xsl:with-param name="key">suseabout</xsl:with-param>
+              </xsl:call-template>
+            </a>
+          </li>
+          <li>
+            <a href="http://www.suse.com/ContactsOffices/contacts_offices.jsp"
+              target="_top">
+              <xsl:call-template name="gentext">
+                <xsl:with-param name="key">susecontact</xsl:with-param>
+              </xsl:call-template>
+            </a>
+          </li>
+        </ul>
+      </xsl:if>
     </div>
-
   </xsl:template>
 
 </xsl:stylesheet>

--- a/suse2013/xhtml/param.xsl
+++ b/suse2013/xhtml/param.xsl
@@ -25,7 +25,7 @@
   <!-- Add a link to a product/company homepage to the logo -->
   <xsl:param name="homepage" select="''"/>
     <!-- Override this parameter from the command line by adding
-             ––xsltparam="'––stringparam homepage=http://www.example.com'"
+             ––stringparam="homepage=http://www.example.com"
          (don't copy from here, for technical reasons I can't use hyphens and
          must use dashes). -->
 
@@ -33,7 +33,7 @@
   <xsl:param name="overview-page" select="''"/>
   <xsl:param name="overview-page-title" select="''"/>
     <!-- Override with
-             ––xsltparam="'––stringparam homepage=http://www.example.com'"
+             ––stringparam="homepage=http://www.example.com"
          (don't copy from here, for technical reasons I can't use hyphens and
          must use dashes). -->
 
@@ -41,7 +41,7 @@
        documentation won't be available at a suse.com address.-->
   <xsl:param name="suse.content" select="1"/>
     <!-- Override with:
-            ––xsltparam="'––param suse.content=0'"
+            ––param="suse.content=0"
          (don't copy from here, for technical reasons I can't use hyphens and
          must use dashes). -->
 
@@ -50,9 +50,17 @@
        installed package. -->
   <xsl:param name="build.for.web" select="1"/>
     <!-- Override with:
-            ––xsltparam="'––param build.for.web=0'"
+            ––param="build.for.web=0"
          (don't copy from here, for technical reasons I can't use hyphens and
          must use dashes). -->
+
+  <!-- Whether to optimize for plain text output -->
+  <xsl:param name="optimize.plain.text" select="0"/>
+    <!-- Override with:
+            ––param="optimize.plain.text=1"
+         (don't copy from here, for technical reasons I can't use hyphens and
+         must use dashes). -->
+
 
 <!-- 1. Admonitions  ============================================ -->
   <!-- Use graphics in admonitions?  0=no, 1=yes -->
@@ -199,19 +207,69 @@ task before
 
   <xsl:param name="admon.graphics.prefix">icon-</xsl:param>
 
+  <!-- Create an image tag for the logo? -->
+  <xsl:param name="generate.logo">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
+
   <xsl:param name="daps.header.logo">static/images/logo.png</xsl:param>
   <xsl:param name="daps.header.logo.alt">Logo</xsl:param>
   <xsl:param name="daps.header.js.library">static/js/jquery-1.10.2.min.js</xsl:param>
   <xsl:param name="daps.header.js.custom">static/js/script.js</xsl:param>
 
-  <xsl:param name="add.suse.footer" select="$suse.content"/>
+  <xsl:param name="generate.header">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
+
+  <!-- Create fixed header bar at the top?  -->
+  <xsl:param name="generate.fixed.header">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
+
+  <xsl:param name="generate.toolbar">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
+
+  <xsl:param name="generate.bottom.navigation">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
 
   <!-- Create breadcrumbs navigation?  -->
-  <xsl:param name="generate.breadcrumbs" select="1"/>
+  <xsl:param name="generate.breadcrumbs">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
+
   <xsl:param name="breadcrumbs.prev">&#9664;<!--&#9668;--></xsl:param>
   <xsl:param name="breadcrumbs.next">&#9654;<!--&#9658;--></xsl:param>
 
   <!--  Bubble TOC options -->
+
+  <!-- Create bubbletoc?  -->
+  <xsl:param name="generate.bubbletoc">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
+
   <xsl:param name="rootelementname">
     <xsl:choose>
       <xsl:when test="local-name(key('id', $rootid)) != ''">
@@ -237,6 +295,17 @@ task before
     </xsl:choose>
   </xsl:param>
 
+  <!-- Generate a footer with SUSE-specific content? -->
+  <xsl:param name="add.suse.footer" select="$suse.content"/>
+
+  <!-- Generate links in said footer? -->
+  <xsl:param name="generate.footer.links">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
+
   <!-- Separator for chapter and book name in the XHTML output -->
   <xsl:param name="head.content.title.separator"> | </xsl:param>
 
@@ -244,7 +313,21 @@ task before
   <xsl:param name="generate.version.info" select="1"/>
 
   <!-- Create the language and format areas in the header? -->
-  <xsl:param name="generate.pickers" select="0"/>
+  <xsl:param name="generate.pickers">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <!-- These are only dummies currently, so we never want to gnerate them. -->
+      <xsl:otherwise>0</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
+
+  <!-- Link at the bottom of the page as a shortcut for printing. -->
+  <xsl:param name="generate.share.and.print">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
 
   <!-- Create sharing links for Facebook, Google+, Twitter? -->
   <xsl:param name="generate.sharelinks" select="1"/>
@@ -256,14 +339,23 @@ task before
   <xsl:param name="daps.breadcrumbs.sep">&#xa0;›&#xa0;</xsl:param>
 
   <!--  Create permalinks?-->
-  <xsl:param name="generate.permalinks" select="1"/>
+  <xsl:param name="generate.permalinks">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
 
   <!-- Should information from SVN properties be used? yes=1|no=0 -->
   <xsl:param name="use.meta" select="0"/>
 
   <!-- Should the tracker meta information be processed? yes=1|no=0 -->
-  <xsl:param name="use.tracker.meta" select="1"/>
-
+  <xsl:param name="use.tracker.meta">
+    <xsl:choose>
+      <xsl:when test="$optimize.plain.text = 1">0</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
   <!-- Show arrows before and after a paragraph that applies only to a certain
        architecture? -->
   <xsl:param name="para.use.arch" select="1"/>
@@ -273,7 +365,7 @@ task before
   -->
 <xsl:param name="warn.xrefs.into.diff.lang" select="1"/>
 
-<xsl:param name="glossentry.show.acronym">yes</xsl:param> 
+<xsl:param name="glossentry.show.acronym">yes</xsl:param>
 
   <!-- Wrap an <img/> tag <a>
        0=no, 1=yes


### PR DESCRIPTION
@tomschr Could you take a look if this makes sense? Also, I am not too fond of the fact that all my new `xsl:param`s have an entire `xsl:choose` inside them... Is there anything else that would make sense from your POV?

Also, this looks a lot more scary than it really is -- the new `xsl:if`s necessitated lots of indentation changes.