### PR TITLE
Fix #228 add transclusion attribute for XIncludes

### DIFF
--- a/schema/rng/0.9/susedoc5-flat.rnc
+++ b/schema/rng/0.9/susedoc5-flat.rnc
@@ -2,14 +2,65 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 namespace ctrl = "http://nwalsh.com/xmlns/schema-control/"
 default namespace db = "http://docbook.org/ns/docbook"
 namespace html = "http://www.w3.org/1999/xhtml"
-namespace local = ""
+namespace local = "http://www.w3.org/2001/XInclude/local-attributes"
+namespace locattr = "http://www.w3.org/2001/XInclude/local-attributes"
 namespace mml = "http://www.w3.org/1998/Math/MathML"
+namespace ns1 = ""
 namespace rng = "http://relaxng.org/ns/structure/1.0"
 namespace s = "http://purl.oclc.org/dsdl/schematron"
 namespace svg = "http://www.w3.org/2000/svg"
+namespace trans = "http://docbook.org/ns/transclusion"
 namespace xi = "http://www.w3.org/2001/XInclude"
 namespace xlink = "http://www.w3.org/1999/xlink"
 
+#
+div {
+  div {
+    div {
+      db.trans.idfixup.attribute =
+        
+        ## Defines a value to be appended to all ID values on the element
+        attribute trans:fixup {
+          
+          ## The suffix property is set to an empty string.
+          "none"
+          | 
+            ## The suffix property is set to the concatenation of the inherited
+            ## suffix value and the value specified in the trans:suffix attribute.
+            "suffix"
+          | 
+            ## The suffix property is set to a unique value for each element.
+            "auto"
+        }
+      db.trans.suffix.attribute =
+        
+        ## This attribute defines the value of the suffix property used when trans:idfixup="suffix".
+        [ a:defaultValue = "" ] attribute trans:suffix { text }
+      db.trans.linkscope.attribute =
+        
+        ## Defines how to correct ID references
+        [ a:defaultValue = "near" ]
+        attribute trans:linkscope {
+          
+          ## No adjustment is made.
+          "user"
+          | 
+            ## Each ID reference is adjusted to point to the closest element that has a matching ID.
+            "near"
+          | 
+            ## Each ID reference is adjusted to point to the first element in document order that has a matching ID.
+            "global"
+          | 
+            ## The value of the suffix property is added to every ID reference as a suffix.
+            "local"
+        }
+      db.xi.trans.attlist =
+        db.trans.idfixup.attribute?
+        & db.trans.suffix.attribute?
+        & db.trans.linkscope.attribute?
+    }
+  }
+}
 # Use a catalog entry to resolve this:
 # include "http://docbook.org/xml/5.1CR3/rng/docbook.rnc"
 div {
@@ -9543,17 +9594,6 @@ div {
         }
     }
     div {
-      db.any.other.attribute = attribute * - local:* { text }
-      db.xi.include.attlist =
-        attribute href {
-          xsd:anyURI { pattern = "[^#]+" }
-        }?,
-        [ a:defaultValue = "xml" ] attribute parse { "xml" | "text" }?,
-        attribute xpointer { text }?,
-        attribute encoding { text }?,
-        attribute accept { text }?,
-        attribute accept-language { text }?,
-        db.any.other.attribute*
       db.xi.include =
         
         ## An XInclude
@@ -10275,6 +10315,7 @@ div {
   # ========= Changed attributes
   db.link.attlist &= db.xlink.simple.link.attributes
   db.version.attribute =
+    
     ## Specifies the DocBook version of the element and its descendants
     attribute version { "5.1-subset SUSEDoc-0.9" | text }
   # ======== Changed content model
@@ -10419,4 +10460,20 @@ div {
         db.varlistentry+
       }
   }
+  # XIncludes
+  db.any.other.attribute =
+    attribute * - (local:* | trans:* | ns1:*) { text }
+  db.xi.include.attlist =
+    
+    ## reference to your included file
+    attribute href {
+      xsd:anyURI { pattern = "[^#]+" }
+    }?,
+    [ a:defaultValue = "xml" ] attribute parse { "xml" | "text" }?,
+    attribute xpointer { text }?,
+    attribute encoding { text }?,
+    attribute accept { text }?,
+    attribute accept-language { text }?,
+    db.any.other.attribute*,
+    db.xi.trans.attlist?
 }

--- a/schema/rng/0.9/susedoc5-flat.rng
+++ b/schema/rng/0.9/susedoc5-flat.rng
@@ -1,4 +1,56 @@
-<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns:ctrl="http://nwalsh.com/xmlns/schema-control/" xmlns:svg="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:db="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://relaxng.org/ns/structure/1.0" ns="http://docbook.org/ns/docbook">
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns:ctrl="http://nwalsh.com/xmlns/schema-control/" xmlns:svg="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:locattr="http://www.w3.org/2001/XInclude/local-attributes" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:db="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:trans="http://docbook.org/ns/transclusion" xmlns="http://relaxng.org/ns/structure/1.0" ns="http://docbook.org/ns/docbook">
+  <!---->
+  <div><div xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:s="http://purl.oclc.org/dsdl/schematron" xmlns:ctrl="http://nwalsh.com/xmlns/schema-control/" xmlns:db="http://docbook.org/ns/docbook" xmlns:local="http://www.w3.org/2001/XInclude/local-attributes" xmlns:trans="http://docbook.org/ns/transclusion" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://relaxng.org/ns/structure/1.0">
+  <div>
+    <define name="db.trans.idfixup.attribute">
+      <attribute name="trans:fixup">
+        <a:documentation>Defines a value to be appended to all ID values on the element</a:documentation>
+        <choice>
+          <value datatypeLibrary="">none</value>
+          <a:documentation>The suffix property is set to an empty string.</a:documentation>
+          <value datatypeLibrary="">suffix</value>
+          <a:documentation>The suffix property is set to the concatenation of the inherited
+suffix value and the value specified in the trans:suffix attribute.</a:documentation>
+          <value datatypeLibrary="">auto</value>
+          <a:documentation>The suffix property is set to a unique value for each element.</a:documentation>
+        </choice>
+      </attribute>
+    </define>
+    <define name="db.trans.suffix.attribute">
+      <attribute name="trans:suffix" a:defaultValue="">
+        <a:documentation>This attribute defines the value of the suffix property used when trans:idfixup="suffix".</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.trans.linkscope.attribute">
+      <attribute name="trans:linkscope" a:defaultValue="near">
+        <a:documentation>Defines how to correct ID references</a:documentation>
+        <choice>
+          <value datatypeLibrary="">user</value>
+          <a:documentation>No adjustment is made.</a:documentation>
+          <value datatypeLibrary="">near</value>
+          <a:documentation>Each ID reference is adjusted to point to the closest element that has a matching ID.</a:documentation>
+          <value datatypeLibrary="">global</value>
+          <a:documentation>Each ID reference is adjusted to point to the first element in document order that has a matching ID.</a:documentation>
+          <value datatypeLibrary="">local</value>
+          <a:documentation>The value of the suffix property is added to every ID reference as a suffix.</a:documentation>
+        </choice>
+      </attribute>
+    </define>
+    <define name="db.xi.trans.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.trans.idfixup.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.trans.suffix.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.trans.linkscope.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+  </div>
+</div></div>
   <!--
     Use a catalog entry to resolve this:
     include "http://docbook.org/xml/5.1CR3/rng/docbook.rnc"
@@ -13303,47 +13355,6 @@ where the nonterminal
     </define>
   </div>
   <div>
-    <define name="db.any.other.attribute">
-      <attribute>
-        <anyName>
-          <except>
-            <nsName ns=""/>
-          </except>
-        </anyName>
-      </attribute>
-    </define>
-    <define name="db.xi.include.attlist">
-      <optional>
-        <attribute name="href">
-          <data type="anyURI" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
-            <param name="pattern">[^#]+</param>
-          </data>
-        </attribute>
-      </optional>
-      <optional>
-        <attribute name="parse" a:defaultValue="xml">
-          <choice>
-            <value datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">xml</value>
-            <value datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">text</value>
-          </choice>
-        </attribute>
-      </optional>
-      <optional>
-        <attribute name="xpointer"/>
-      </optional>
-      <optional>
-        <attribute name="encoding"/>
-      </optional>
-      <optional>
-        <attribute name="accept"/>
-      </optional>
-      <optional>
-        <attribute name="accept-language"/>
-      </optional>
-      <zeroOrMore>
-        <ref name="db.any.other.attribute"/>
-      </zeroOrMore>
-    </define>
     <define name="db.xi.include">
       <element name="xi:include">
         <a:documentation>An XInclude</a:documentation>
@@ -15114,9 +15125,9 @@ where the nonterminal
           <attribute name="shortentry">
             <a:documentation>Indicates if the short or long title should be used in a List of Tables</a:documentation>
             <choice>
-              <value datatypeLibrary="">0</value>
+              <value datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">0</value>
               <a:documentation>Indicates that the full title should be used.</a:documentation>
-              <value datatypeLibrary="">1</value>
+              <value datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">1</value>
               <a:documentation>Indicates that the short short title (titleabbrev) should be used.</a:documentation>
             </choice>
           </attribute>
@@ -15125,9 +15136,9 @@ where the nonterminal
           <attribute name="tocentry">
             <a:documentation>Indicates if the table should appear in a List of Tables</a:documentation>
             <choice>
-              <value datatypeLibrary="">0</value>
+              <value datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">0</value>
               <a:documentation>Indicates that the table should not occur in the List of Tables.</a:documentation>
-              <value datatypeLibrary="">1</value>
+              <value datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">1</value>
               <a:documentation>Indicates that the table should appear in the List of Tables.</a:documentation>
             </choice>
           </attribute>
@@ -15183,7 +15194,7 @@ where the nonterminal
       <attribute name="version">
         <a:documentation>Specifies the DocBook version of the element and its descendants</a:documentation>
         <choice>
-          <value datatypeLibrary="">5.1-subset SUSEDoc-0.9</value>
+          <value datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">5.1-subset SUSEDoc-0.9</value>
           <text/>
         </choice>
       </attribute>
@@ -15363,5 +15374,53 @@ where the nonterminal
         </element>
       </define>
     </div>
+    <!-- XIncludes -->
+    <define name="db.any.other.attribute">
+      <attribute>
+        <anyName>
+          <except>
+            <nsName ns="http://www.w3.org/2001/XInclude/local-attributes"/>
+            <nsName ns="http://docbook.org/ns/transclusion"/>
+            <nsName ns=""/>
+          </except>
+        </anyName>
+      </attribute>
+    </define>
+    <define name="db.xi.include.attlist">
+      <optional>
+        <attribute name="href">
+          <a:documentation>reference to your included file</a:documentation>
+          <data type="anyURI" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+            <param name="pattern">[^#]+</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="parse" a:defaultValue="xml">
+          <choice>
+            <value datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">xml</value>
+            <value datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">text</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="xpointer"/>
+      </optional>
+      <optional>
+        <attribute name="encoding"/>
+      </optional>
+      <optional>
+        <attribute name="accept"/>
+      </optional>
+      <optional>
+        <attribute name="accept-language"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="db.any.other.attribute"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="db.xi.trans.attlist"/>
+      </optional>
+    </define>
   </div>
 </grammar>

--- a/schema/rng/0.9/susedoc5.rnc
+++ b/schema/rng/0.9/susedoc5.rnc
@@ -16,8 +16,17 @@ namespace mml = "http://www.w3.org/1998/Math/MathML"
 namespace svg = "http://www.w3.org/2000/svg"
 namespace s = "http://purl.oclc.org/dsdl/schematron"
 namespace xlink = "http://www.w3.org/1999/xlink"
+namespace local = ""
+
+# Namespace for DocBook Transclusions
+# See http://docbook.org/docs/transclusion/
+namespace locattr="http://www.w3.org/2001/XInclude/local-attributes"
+namespace trans="http://docbook.org/ns/transclusion"
 
 datatypes xsd = "http://www.w3.org/2001/XMLSchema-datatypes"
+
+#
+include "transclusion.rnc"
 
 # Use a catalog entry to resolve this:
 # include "http://docbook.org/xml/5.1CR3/rng/docbook.rnc"
@@ -821,7 +830,6 @@ include "docbookxi.rnc"
       }?
     & db.rowheader.attribute?
 
-
   db.task.attlist =
     db.task.role.attribute?
     & db.common.attributes
@@ -992,6 +1000,21 @@ include "docbookxi.rnc"
         db.varlistentry+
       }
   }
+
+  # XIncludes
+  db.any.other.attribute = attribute * - (locattr:* | trans:* | local:*) { text }
+  db.xi.include.attlist =
+    ## reference to your included file
+    attribute href {
+      xsd:anyURI { pattern = "[^#]+" }
+    }?,
+    [ a:defaultValue = "xml" ] attribute parse { "xml" | "text" }?,
+    attribute xpointer { text }?,
+    attribute encoding { text }?,
+    attribute accept { text }?,
+    attribute accept-language { text }?,
+    db.any.other.attribute*,
+    db.xi.trans.attlist?
 
 } # end of include
 

--- a/schema/rng/0.9/transclusion.rnc
+++ b/schema/rng/0.9/transclusion.rnc
@@ -1,0 +1,62 @@
+#
+# DocBook 5.1 Transclusion Schema (Simple)
+#
+# Namespace for DocBook Transclusions
+# See http://docbook.org/docs/transclusion/
+
+namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
+namespace ctrl = "http://nwalsh.com/xmlns/schema-control/"
+namespace db = "http://docbook.org/ns/docbook"
+namespace local = "http://www.w3.org/2001/XInclude/local-attributes"
+namespace s = "http://purl.oclc.org/dsdl/schematron"
+namespace trans = "http://docbook.org/ns/transclusion"
+namespace xi = "http://www.w3.org/2001/XInclude"
+namespace xlink = "http://www.w3.org/1999/xlink"
+
+div {
+ db.trans.idfixup.attribute =
+
+  ## Defines a value to be appended to all ID values on the element
+  attribute trans:fixup {
+   
+   ## The suffix property is set to an empty string.
+   "none"
+   | 
+     ## The suffix property is set to the concatenation of the inherited
+     ## suffix value and the value specified in the trans:suffix attribute.
+     "suffix"
+   | 
+     ## The suffix property is set to a unique value for each element.
+     "auto"
+  }
+
+ db.trans.suffix.attribute =
+  
+  ## This attribute defines the value of the suffix property used when trans:idfixup="suffix".
+  [ a:defaultValue = "" ] attribute trans:suffix { text }
+
+
+ db.trans.linkscope.attribute =
+
+  ## Defines how to correct ID references
+  [ a:defaultValue = "near" ]
+  attribute trans:linkscope {
+
+   ## No adjustment is made.
+   "user"
+   | 
+     ## Each ID reference is adjusted to point to the closest element that has a matching ID.
+     "near"
+   | 
+     ## Each ID reference is adjusted to point to the first element in document order that has a matching ID.
+     "global"
+   | 
+     ## The value of the suffix property is added to every ID reference as a suffix.
+     "local"
+  }
+
+ db.xi.trans.attlist =
+  db.trans.idfixup.attribute? &
+  db.trans.suffix.attribute? &
+  db.trans.linkscope.attribute?
+}


### PR DESCRIPTION
@sknorr Could you please review this?

I've added the transclusion attributes `trans:idfixup`, `trans:suffix`, and `trans:linkscope ` from http://docbook.org/docs/transclusion/ which is needed for openSUSE/dbxincluder#3.

The spec has some side conditions. For example, when choosing `trans:idfixup="none"`, `trans:suffix` must be an empty string. At the moment, this is not implemented, so I consider this as a first start. Either this is checked by dbxincluder, or the RNC schema could be improved.

You can ignore the `susedoc5-flat.rng?` files as they are generated. 