### PR TITLE
breadcrumb: add separator between set and book

### DIFF
--- a/suse/xhtml/navig.header.footer.xsl
+++ b/suse/xhtml/navig.header.footer.xsl
@@ -247,7 +247,7 @@ orientation: <xsl:value-of select="$orientation"/>
       </xsl:attribute>
       <xsl:apply-templates select="." mode="title.markup"/>
     </xsl:element>
-    <xsl:if test="following-sibling::*[
+    <xsl:if test="self::set or following-sibling::*[
                     self::chapter|self::article|self::book
                     |self::part|self::preface|self::appendix|self::glossary
                     |self::sect1|self::bibliography]">


### PR DESCRIPTION
This comes from [SUSE Manager bug 981538](https://bugzilla.suse.com/show_bug.cgi?id=981538).

Breadcrumbs have set name and book named squashed together, hence I am adding a breadcrumb separator.

Before (note "SUSE Manager 3Reference Manual"):
![before](https://cloud.githubusercontent.com/assets/250541/20487129/80066fa6-b002-11e6-97b2-0ae400bf211b.png)

After:
![after](https://cloud.githubusercontent.com/assets/250541/20487134/83176a88-b002-11e6-998a-b63e8f3375d8.png)
