### PR TITLE
Fixes behavior of link templates.

### DIFF
--- a/suse2013/fo/xref.xsl
+++ b/suse2013/fo/xref.xsl
@@ -145,7 +145,7 @@
 </xsl:template>
 
 
-<xsl:template match="xref" name="xref">
+<xsl:template match="xref|link[@linkend]" name="xref">
   <xsl:variable name="targets" select="key('id',@linkend)"/>
   <xsl:variable name="target" select="$targets[1]"/>
   <xsl:variable name="refelem" select="local-name($target)"/>

--- a/suse2013/fo/xref.xsl
+++ b/suse2013/fo/xref.xsl
@@ -165,9 +165,8 @@
   <xsl:choose>
     <xsl:when test="$xref.in.samebook != 0 or
                     /set/@id=$rootid or
-                    /article/@id=$rootid">
-       <!-- An xref that stays inside the current book or when $rootid
-         pointing to the root element, then use the defaults -->
+                    /set/@xml:id=$rootid">
+       <!-- An xref that is within the current book or article -->
        <xsl:apply-imports/>
     </xsl:when>
     <xsl:otherwise>

--- a/suse2013/xhtml/xref.xsl
+++ b/suse2013/xhtml/xref.xsl
@@ -153,7 +153,7 @@
   <xsl:when test="$rootid != '' and $xref.in.samebook != 0">
    <xsl:apply-imports/>
   </xsl:when>
-  <xsl:when test="$xref.in.samebook != 0 or /set/@id=$rootid or /article/@id=$rootid">
+  <xsl:when test="$xref.in.samebook != 0 or /set/@id=$rootid or /set/@xml:id=$rootid">
    <!-- An xref that stays inside the current book or when $rootid
          pointing to the root element, then use the defaults -->
    <xsl:apply-imports/>

--- a/suse2013/xhtml/xref.xsl
+++ b/suse2013/xhtml/xref.xsl
@@ -13,7 +13,8 @@
 
 <xsl:stylesheet version="1.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns="http://www.w3.org/1999/xhtml">
+  xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
 
 
   <xsl:template name="anchor">
@@ -74,8 +75,8 @@
     <xsl:apply-templates select="."/>
   </xsl:template>
 
-  <xsl:template match="ulink" name="ulink">
-    <xsl:param name="url" select="@url"/>
+  <xsl:template match="ulink|link" name="ulink">
+    <xsl:param name="url" select="@url|@xlink:href"/>
     <xsl:variable name="link-text">
       <xsl:apply-templates mode="no.anchor.mode"/>
     </xsl:variable>
@@ -121,7 +122,7 @@
   </xsl:template>
 
 
-<xsl:template match="xref" name="xref">
+<xsl:template match="xref|link[@linkend]" name="xref">
   <xsl:variable name="targets" select="key('id',@linkend)"/>
   <xsl:variable name="target" select="$targets[1]"/>
   <xsl:variable name="refelem" select="local-name($target)"/>


### PR DESCRIPTION
xref and link can now be used interchangeable.
link xlink:href is now supported for HTML.