### PR TITLE
Fix text scaling (e.g. for Chinese)

### DIFF
--- a/suse2013/fo/appendix.titlepage.templates.xsl
+++ b/suse2013/fo/appendix.titlepage.templates.xsl
@@ -27,7 +27,7 @@
   <xsl:template match="title" mode="appendix.titlepage.recto.auto.mode">
     <fo:block
       xsl:use-attribute-sets="appendix.titlepage.recto.style component.title.style"
-      font-size="&super-large;pt" font-family="{$title.fontset}">
+      font-size="{&super-large; * $fontsize-adjust * $sans-xheight-adjust}pt" font-family="{$title.fontset}">
       <xsl:attribute name="margin-{$start-border}">
         <xsl:value-of select="$title.margin.left"/>
       </xsl:attribute>
@@ -40,7 +40,7 @@
   <xsl:template match="subtitle" mode="appendix.titlepage.recto.auto.mode">
     <fo:block
       xsl:use-attribute-sets="appendix.titlepage.recto.style"
-      font-family="{$title.fontset}" font-size="&small;pt">
+      font-family="{$title.fontset}" font-size="{&small; * $fontsize-adjust * $sans-xheight-adjust}pt">
       <xsl:apply-templates select="." mode="appendix.titlepage.recto.mode"/>
     </fo:block>
   </xsl:template>
@@ -48,7 +48,7 @@
   <xsl:template match="corpauthor" mode="appendix.titlepage.recto.auto.mode">
     <fo:block
       xsl:use-attribute-sets="appendix.titlepage.recto.style"
-      font-family="{$title.fontset}" font-size="&small;pt">
+      font-family="{$title.fontset}" font-size="{&small; * $fontsize-adjust * $sans-xheight-adjust}pt">
       <xsl:apply-templates select="." mode="appendix.titlepage.recto.mode"/>
     </fo:block>
   </xsl:template>
@@ -56,7 +56,7 @@
   <xsl:template match="authorgroup" mode="appendix.titlepage.recto.auto.mode">
     <fo:block
       xsl:use-attribute-sets="appendix.titlepage.recto.style"
-      font-family="{$title.fontset}" font-size="&small;pt">
+      font-family="{$title.fontset}" font-size="{&small; * $fontsize-adjust * $sans-xheight-adjust}pt">
       <xsl:apply-templates select="." mode="appendix.titlepage.recto.mode"/>
     </fo:block>
   </xsl:template>
@@ -64,7 +64,7 @@
   <xsl:template match="author" mode="appendix.titlepage.recto.auto.mode">
     <fo:block
       xsl:use-attribute-sets="appendix.titlepage.recto.style"
-      font-family="{$title.fontset}" font-size="&small;pt">
+      font-family="{$title.fontset}" font-size="{&small; * $fontsize-adjust * $sans-xheight-adjust}pt">
       <xsl:apply-templates select="." mode="appendix.titlepage.recto.mode"/>
     </fo:block>
   </xsl:template>
@@ -72,7 +72,7 @@
   <xsl:template match="othercredit" mode="appendix.titlepage.recto.auto.mode">
     <fo:block
       xsl:use-attribute-sets="appendix.titlepage.recto.style"
-      font-family="{$title.fontset}" font-size="&small;pt">
+      font-family="{$title.fontset}" font-size="{&small; * $fontsize-adjust * $sans-xheight-adjust}pt">
       <xsl:apply-templates select="." mode="appendix.titlepage.recto.mode"/>
     </fo:block>
   </xsl:template>

--- a/suse2013/fo/article.titlepage.templates.xsl
+++ b/suse2013/fo/article.titlepage.templates.xsl
@@ -160,7 +160,7 @@
   </xsl:template>
 
   <xsl:template match="title" mode="article.titlepage.recto.auto.mode">
-    <fo:block font-size="&super-large;pt" line-height="{$base-lineheight * 0.85}em"
+    <fo:block font-size="{&super-large; * $fontsize-adjust * $sans-xheight-adjust}pt" line-height="{$base-lineheight * 0.85}em"
       xsl:use-attribute-sets="article.titlepage.recto.style dark-green"
       keep-with-next.within-column="always" space-after="{&gutterfragment;}mm">
       <xsl:apply-templates select="." mode="article.titlepage.recto.mode"/>
@@ -168,7 +168,7 @@
   </xsl:template>
 
   <xsl:template match="subtitle" mode="article.titlepage.recto.auto.mode">
-    <fo:block font-size="&xx-large;pt" line-height="{$base-lineheight * 0.75}em"
+    <fo:block font-size="{&xx-large; * $fontsize-adjust * $sans-xheight-adjust}pt" line-height="{$base-lineheight * 0.75}em"
       xsl:use-attribute-sets="article.titlepage.recto.style mid-green"
       keep-with-next.within-column="always" space-after="{&gutterfragment;}mm">
       <xsl:apply-templates select="." mode="article.titlepage.recto.mode"/>
@@ -176,7 +176,7 @@
   </xsl:template>
 
   <xsl:template match="productname[1]" mode="article.titlepage.recto.auto.mode">
-    <fo:block text-align="start" font-size="&xx-large;pt"
+    <fo:block text-align="start" font-size="{&xx-large; * $fontsize-adjust * $sans-xheight-adjust}pt"
       xsl:use-attribute-sets="mid-green">
       <xsl:apply-templates select="." mode="article.titlepage.recto.mode"/>
       <xsl:if test="../productnumber">
@@ -187,7 +187,7 @@
   </xsl:template>
 
   <xsl:template match="authorgroup" mode="article.titlepage.recto.auto.mode">
-    <fo:block font-size="&large;pt" space-before="1em" text-align="start">
+    <fo:block font-size="{&large; * $fontsize-adjust * $sans-xheight-adjust}pt" space-before="1em" text-align="start">
       <xsl:call-template name="person.name.list">
         <xsl:with-param name="person.list" select="author|corpauthor"/>
       </xsl:call-template>
@@ -196,7 +196,7 @@
 
   <xsl:template match="author|corpauthor"
     mode="article.titlepage.recto.auto.mode">
-    <fo:block space-before="1em" font-size="&large;pt" text-align="start">
+    <fo:block space-before="1em" font-size="{&large; * $fontsize-adjust * $sans-xheight-adjust}pt" text-align="start">
       <xsl:apply-templates select="." mode="article.titlepage.recto.mode"/>
     </fo:block>
   </xsl:template>
@@ -204,7 +204,7 @@
   <xsl:template match="editor|othercredit"
     mode="article.titlepage.recto.auto.mode">
     <xsl:if test=". = ((../othercredit)|(../editor))[1]">
-      <fo:block font-size="&normal;pt">
+      <fo:block font-size="{&normal; * $fontsize-adjust * $sans-xheight-adjust}pt">
         <xsl:call-template name="gentext">
           <xsl:with-param name="key">
             <xsl:choose>

--- a/suse2013/fo/attributesets.xsl
+++ b/suse2013/fo/attributesets.xsl
@@ -32,7 +32,7 @@
 <xsl:attribute-set name="admonition.title.properties">
   <xsl:attribute name="font-family"><xsl:value-of select="$title.font.family"/></xsl:attribute>
   <xsl:attribute name="font-weight">normal</xsl:attribute>
-  <xsl:attribute name="font-size">&x-large;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&x-large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
   <xsl:attribute name="hyphenate">false</xsl:attribute>
   <xsl:attribute name="keep-with-next.within-column">always</xsl:attribute>
   <xsl:attribute name="text-align">start</xsl:attribute>
@@ -89,25 +89,25 @@
 <xsl:attribute-set name="toc.level1.properties"
   use-attribute-sets="toc.common.properties title.name.color">
   <xsl:attribute name="font-weight">normal</xsl:attribute>
-  <xsl:attribute name="font-size">&large;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
   <xsl:attribute name="text-transform">uppercase</xsl:attribute>
 </xsl:attribute-set>
 <!-- preface, chapter, appendix, glossary -->
 <xsl:attribute-set name="toc.level2.properties"
   use-attribute-sets="toc.common.properties sans.bold.noreplacement">
   <xsl:attribute name="line-height"><xsl:value-of select="$base-lineheight * 0.85"/>em</xsl:attribute>
-  <xsl:attribute name="font-size">&xx-large;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&xx-large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
 </xsl:attribute-set>
 <!-- sect1 -->
 <xsl:attribute-set name="toc.level3.properties"
   use-attribute-sets="toc.common.properties">
-  <xsl:attribute name="font-size">&large;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
   <xsl:attribute name="font-weight">normal</xsl:attribute>
 </xsl:attribute-set>
 <!-- sect2 -->
 <xsl:attribute-set name="toc.level4.properties"
   use-attribute-sets="toc.common.properties">
-  <xsl:attribute name="font-size">&normal;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&normal; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
   <xsl:attribute name="font-weight">normal</xsl:attribute>
 </xsl:attribute-set>
 
@@ -187,7 +187,7 @@
 <xsl:attribute-set name="variablelist.term.properties"
   use-attribute-sets="sans.bold.noreplacement">
   <xsl:attribute name="font-family"><xsl:value-of select="$sans.font.family"/></xsl:attribute>
-  <xsl:attribute name="font-size"><xsl:value-of select="$fontsize-adjust * $sans-xheight-adjust"/>em</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="$sans-xheight-adjust"/>em</xsl:attribute>
   <xsl:attribute name="line-height"><xsl:value-of select="$base-lineheight * $sans-lineheight-adjust"/>em</xsl:attribute>
 </xsl:attribute-set>
 
@@ -198,7 +198,7 @@
 <xsl:attribute-set name="orderedlist.label.properties"
   use-attribute-sets="lists.label.properties sans.bold">
   <xsl:attribute name="font-family"><xsl:value-of select="$sans-stack"/></xsl:attribute>
-  <xsl:attribute name="font-size"><xsl:value-of select="$fontsize-adjust * $sans-xheight-adjust"/>em</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="$sans-xheight-adjust"/>em</xsl:attribute>
   <xsl:attribute name="line-height"><xsl:value-of select="$base-lineheight * $sans-lineheight-adjust"/>em</xsl:attribute>
 </xsl:attribute-set>
 <xsl:attribute-set name="itemizedlist.label.properties"
@@ -321,7 +321,7 @@
     <xsl:value-of select="$sans.font.family"/>
   </xsl:attribute>
   <xsl:attribute name="font-size">
-    <xsl:text>&small;pt</xsl:text>
+    <xsl:value-of select="&small; * $fontsize-adjust * $sans-xheight-adjust"/>pt
   </xsl:attribute>
   <xsl:attribute name="margin-{$start-border}">
     <xsl:value-of select="$title.margin.left"/>
@@ -394,7 +394,9 @@
   <xsl:attribute name="text-align">start</xsl:attribute>
   <xsl:attribute name="wrap-option">wrap</xsl:attribute>
   <xsl:attribute name="hyphenation-character"><xsl:value-of select="$hook"/></xsl:attribute>
-  <xsl:attribute name="font-size">&small;pt</xsl:attribute>
+  <!-- Is this the right solution or leave this hard-coded (i.e. without
+  $fontsize-adjust)? We need at least 80 characters on a line... -->
+  <xsl:attribute name="font-size"><xsl:value-of select="&small; * $fontsize-adjust * $mono-xheight-adjust"/>pt</xsl:attribute>
   <xsl:attribute name="line-height"><xsl:value-of select="$base-lineheight"/>em</xsl:attribute>
 </xsl:attribute-set>
 
@@ -416,30 +418,30 @@
 </xsl:attribute-set>
 
 <xsl:attribute-set name="section.title.level1.properties">
-  <xsl:attribute name="font-size">&xxx-large;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&xxx-large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
 </xsl:attribute-set>
 <xsl:attribute-set name="section.title.level2.properties">
-  <xsl:attribute name="font-size">&xx-large;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&xx-large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
 </xsl:attribute-set>
 <xsl:attribute-set name="section.title.level3.properties">
-  <xsl:attribute name="font-size">&x-large;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&x-large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
 </xsl:attribute-set>
 <xsl:attribute-set name="section.title.level4.properties"
   use-attribute-sets="sans.bold.noreplacement">
-  <xsl:attribute name="font-size">&large;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
 </xsl:attribute-set>
 <xsl:attribute-set name="section.title.level5.properties">
-  <xsl:attribute name="font-size">&large;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
 </xsl:attribute-set>
 <xsl:attribute-set name="section.title.level6.properties"
   use-attribute-sets="sans.bold.noreplacement">
-  <xsl:attribute name="font-size">&normal;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&normal; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
 </xsl:attribute-set>
 
 <xsl:attribute-set name="formal.title.properties"
   use-attribute-sets="normal.para.spacing dark-green sans.bold.noreplacement">
   <xsl:attribute name="font-family"><xsl:value-of select="$sans.font.family"/></xsl:attribute>
-  <xsl:attribute name="font-size">&small;pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&small; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
   <xsl:attribute name="text-transform">uppercase</xsl:attribute>
   <xsl:attribute name="hyphenate">false</xsl:attribute>
   <xsl:attribute name="space-before.minimum">0.8em</xsl:attribute>
@@ -456,7 +458,7 @@
 
 <xsl:attribute-set name="abstract.properties">
   <xsl:attribute name="font-family"><xsl:value-of select="$body.font.family"/></xsl:attribute>
-  <xsl:attribute name="font-size"><xsl:value-of select="(&normal; * $fontsize-adjust) div $mono-xheight-adjust"/>pt</xsl:attribute>
+  <xsl:attribute name="font-size"><xsl:value-of select="&large; * $fontsize-adjust"/>pt</xsl:attribute>
   <xsl:attribute name="text-align">start</xsl:attribute>
   <xsl:attribute name="line-height">4em</xsl:attribute>
   <xsl:attribute name="start-indent">inherit</xsl:attribute>

--- a/suse2013/fo/attributesets.xsl
+++ b/suse2013/fo/attributesets.xsl
@@ -148,7 +148,7 @@
      font, thus they use x-height scaling adapted to work inside sans
      text. Welp.
      xref.properties are also applied to ulinks, to be consistent. -->
-<xsl:attribute-set name="xref.properties"
+<xsl:attribute-set name="xref.basic.properties"
                    use-attribute-sets="title.font">
   <xsl:attribute name="font-style">
     <xsl:choose>
@@ -171,13 +171,17 @@
       <xsl:otherwise>1em</xsl:otherwise>
     </xsl:choose>
   </xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:attribute-set name="xref.properties"
+                   use-attribute-sets="title.font xref.basic.properties">
   <xsl:attribute name="color">
     <xsl:choose>
      <xsl:when test="ancestor::remark">&white;</xsl:when>
      <xsl:otherwise>
       <xsl:value-of select="$dark-green"/>
      </xsl:otherwise>
-  </xsl:choose>
+    </xsl:choose>
   </xsl:attribute>
 </xsl:attribute-set>
 

--- a/suse2013/fo/autotoc.xsl
+++ b/suse2013/fo/autotoc.xsl
@@ -123,7 +123,7 @@
   <fo:list-item>
     <fo:list-item-label end-indent="label-end()">
       <fo:block text-align="end" width="&column;mm" font-family="{$title.fontset}"
-        font-size="&large;pt" line-height="{$line-height}">
+        font-size="{&large; * $fontsize-adjust * $sans-xheight-adjust}pt" line-height="{$line-height}">
         <fo:basic-link internal-destination="{$id}">
           <xsl:if test="$label != ''">
             <xsl:copy-of select="$label"/>
@@ -135,12 +135,12 @@
       <fo:block line-height="{$line-height}" padding-after="{&gutter; div 2}mm">
         <fo:basic-link internal-destination="{$id}">
           <fo:inline keep-with-next.within-line="always"
-            font-family="{$title.fontset}" font-size="&large;pt">
+            font-family="{$title.fontset}" font-size="{&large; * $fontsize-adjust * $sans-xheight-adjust}pt">
             <xsl:apply-templates select="." mode="titleabbrev.markup"/>
           </fo:inline>
           <fo:leader leader-pattern="space" leader-length="&gutterfragment;mm"
             keep-with-next.within-line="always"/>
-          <fo:inline keep-together.within-line="always" font-size="&large;pt"
+          <fo:inline keep-together.within-line="always" font-size="{&large; * $fontsize-adjust * $sans-xheight-adjust}pt"
             xsl:use-attribute-sets="toc.pagenumber.properties" color="&mid-gray;">
             <fo:page-number-citation ref-id="{$id}"/>
           </fo:inline>
@@ -266,7 +266,7 @@
     </xsl:variable>
 
     <fo:list-block role="TOC.{local-name()}" relative-align="baseline"
-       font-size="&xx-large;pt"
+       font-size="{&xx-large; * $fontsize-adjust * $sans-xheight-adjust}pt"
        keep-with-next.within-column="always"
        xsl:use-attribute-sets="toc.level2.properties dark-green sans.bold.noreplacement"
        provisional-distance-between-starts="{&column; + &gutter;}mm"

--- a/suse2013/fo/bibliography.titlepage.templates.xsl
+++ b/suse2013/fo/bibliography.titlepage.templates.xsl
@@ -26,7 +26,7 @@
   <xsl:template name="bibliography.titlepage.recto">
     <fo:block
       xsl:use-attribute-sets="bibliography.titlepage.recto.style"
-      font-size="&super-large;pt" font-family="{$title.fontset}">
+      font-size="{&super-large; * $fontsize-adjust * $sans-xheight-adjust}pt" font-family="{$title.fontset}">
       <xsl:attribute name="margin-{$start-border}">
         <xsl:value-of select="$title.margin.left"/>
       </xsl:attribute>

--- a/suse2013/fo/block.xsl
+++ b/suse2013/fo/block.xsl
@@ -100,7 +100,7 @@
 
   <xsl:if test="$title-str != ''">
     <fo:inline keep-with-next.within-line="always"
-      font-size="{$sans-xheight-adjust}em" padding-end="0.2em"
+      padding-end="0.2em"
       xsl:use-attribute-sets="variablelist.term.properties">
       <xsl:copy-of select="$title-str"/>
       <xsl:if test="$last-char != ''

--- a/suse2013/fo/book.titlepage.templates.xsl
+++ b/suse2013/fo/book.titlepage.templates.xsl
@@ -154,7 +154,7 @@
 
 <xsl:template match="subtitle" mode="book.titlepage.recto.auto.mode">
   <fo:block
-    xsl:use-attribute-sets="title.font" font-size="&super-large;pt"
+    xsl:use-attribute-sets="title.font" font-size="{&super-large; * $fontsize-adjust * $sans-xheight-adjust}pt"
     space-before="&gutterfragment;mm">
     <xsl:apply-templates select="." mode="book.titlepage.recto.mode"/>
   </fo:block>
@@ -164,7 +164,7 @@
   mode="book.titlepage.recto.auto.mode">
   <fo:block text-align="start" hyphenate="false"
     line-height="{$base-lineheight * 0.85}em"
-    font-weight="normal" font-size="&super-large;pt"
+    font-weight="normal" font-size="{&super-large; * $fontsize-adjust * $sans-xheight-adjust}pt"
     space-after="&gutterfragment;mm"
     xsl:use-attribute-sets="title.font sans.bold.noreplacement mid-green">
     <xsl:apply-templates select="." mode="book.titlepage.recto.mode"/>
@@ -177,14 +177,14 @@
 <xsl:template match="title" mode="book.titlepage.verso.auto.mode">
   <fo:block
     xsl:use-attribute-sets="book.titlepage.verso.style sans.bold"
-    font-size="&x-large;pt" font-family="{$title.fontset}">
+    font-size="{&x-large; * $fontsize-adjust * $sans-xheight-adjust}pt" font-family="{$title.fontset}">
     <xsl:call-template name="book.verso.title"/>
   </fo:block>
 </xsl:template>
 
 <xsl:template match="legalnotice" mode="book.titlepage.verso.auto.mode">
   <fo:block
-    xsl:use-attribute-sets="book.titlepage.verso.style" font-size="&small;pt">
+    xsl:use-attribute-sets="book.titlepage.verso.style" font-size="{&small; * $fontsize-adjust}pt">
     <xsl:apply-templates select="*" mode="book.titlepage.verso.mode"/>
   </fo:block>
 </xsl:template>
@@ -304,7 +304,7 @@
 </xsl:template>
 
 <xsl:template match="title" mode="book.titlepage.verso.auto.mode">
-    <fo:block font-size="&x-large;pt"
+    <fo:block font-size="{&x-large; * $fontsize-adjust * $sans-xheight-adjust}pt"
       xsl:use-attribute-sets="book.titlepage.verso.style dark-green sans.bold.noreplacement title.font">
       <xsl:call-template name="book.verso.title"/>
     </fo:block>
@@ -312,7 +312,7 @@
 
 <xsl:template match="productname[not(@role='abbrev')]" mode="book.titlepage.verso.auto.mode">
   <fo:block xsl:use-attribute-sets="book.titlepage.verso.style"
-    font-size="&large;pt" font-family="{$title.fontset}">
+    font-size="{&large; * $fontsize-adjust * $sans-xheight-adjust}pt" font-family="{$title.fontset}">
     <xsl:apply-templates select="." mode="book.titlepage.verso.mode"/>
     <xsl:text> </xsl:text>
     <xsl:if test="../productnumber">
@@ -341,7 +341,7 @@
 </xsl:template>
 
 <xsl:template match="editor" mode="book.titlepage.verso.auto.mode">
-  <fo:block font-size="&normal;pt">
+  <fo:block font-size="{&normal; * $fontsize-adjust * $sans-xheight-adjust}pt">
     <xsl:apply-templates select="." mode="book.titlepage.verso.mode"/>
   </fo:block>
 </xsl:template>

--- a/suse2013/fo/callout.xsl
+++ b/suse2013/fo/callout.xsl
@@ -25,9 +25,9 @@
 <xsl:template name="callout-bug">
   <xsl:param name="conum" select='1'/>
   <xsl:variable name="instream-font-size" select="80"/>
+   <!-- Most fonts's default figures are so-called "tabular figures," that is,
+        monospaced figures. Don't use a font where that doesn't apply here. -->
   <xsl:variable name="font-metrics-ratio" select="&sans-numbers-ratio;"/>
-    <!-- Most fonts's default figures are so-called "tabular figures," that is,
-         monospaced figures. Don't use a font where that doesn't apply here. -->
   <xsl:variable name="width">
     <xsl:choose>
       <xsl:when test="$conum &lt; 10">100</xsl:when>
@@ -46,13 +46,13 @@
     <svg:svg xmlns:svg="http://www.w3.org/2000/svg" height="100px" width="{$width}">
       <svg:rect height="100" rx="50" ry="50" x="0" y="0"
         fill="{$color}" stroke="none" width="{$width}"/>
-      <svg:text y="{$instream-font-size - 1}" fill="&white;" font-family="{$sans-stack}"
+      <svg:text y="{$instream-font-size - 1}" fill="&white;" font-family="{$callout-font-stack}"
         font-size="{$instream-font-size}" text-anchor="middle"
-        xsl:use-attribute-sets="sans.bold.noreplacement">
+        font-weight="{$callout-font-weight}">
         <xsl:attribute name="x">
           <xsl:choose>
-            <xsl:when test="substring($conum,1,1) = 1">
-              <xsl:value-of select="($width div 2) - 7"/>
+            <xsl:when test="substring($conum,1,1) = '1'">
+              <xsl:value-of select="($width div 2) - 3"/>
             </xsl:when>
               <!-- Callout (1) as well as (10) and up will be horribly
                    off-center if they are not special-cased. -->

--- a/suse2013/fo/chapter.titlepage.templates.xsl
+++ b/suse2013/fo/chapter.titlepage.templates.xsl
@@ -26,7 +26,7 @@
   <xsl:template match="title" mode="chapter.titlepage.recto.auto.mode">
     <fo:block
       xsl:use-attribute-sets="chapter.titlepage.recto.style component.title.style"
-      font-size="&super-large;pt">
+      font-size="{&super-large; * $fontsize-adjust * $sans-xheight-adjust}pt">
       <xsl:call-template name="component.title">
         <xsl:with-param name="node" select="ancestor-or-self::chapter[1]"/>
       </xsl:call-template>
@@ -36,7 +36,7 @@
   <xsl:template match="subtitle" mode="chapter.titlepage.recto.auto.mode">
     <fo:block
       xsl:use-attribute-sets="chapter.titlepage.recto.style italicized.noreplacement"
-      font-size="&large;pt" font-family="{$title.fontset}">
+      font-size="{&large; * $fontsize-adjust * $sans-xheight-adjust}pt" font-family="{$title.fontset}">
       <xsl:apply-templates select="." mode="chapter.titlepage.recto.mode"/>
     </fo:block>
   </xsl:template>
@@ -44,14 +44,14 @@
   <xsl:template match="author|corpauthor|authorgroup" mode="chapter.titlepage.recto.auto.mode">
     <fo:block
       xsl:use-attribute-sets="chapter.titlepage.recto.style"
-      space-after="0.5em" font-size="&small;pt" font-family="{$title.fontset}">
+      space-after="0.5em" font-size="{&small; * $fontsize-adjust * $sans-xheight-adjust}pt" font-family="{$title.fontset}">
       <xsl:apply-templates select="." mode="chapter.titlepage.recto.mode"/>
     </fo:block>
   </xsl:template>
 
   <xsl:template match="othercredit" mode="chapter.titlepage.recto.auto.mode">
     <fo:block
-      xsl:use-attribute-sets="chapter.titlepage.recto.style" font-size="&small;pt"
+      xsl:use-attribute-sets="chapter.titlepage.recto.style" font-size="{&small; * $fontsize-adjust * $sans-xheight-adjust}pt"
       font-family="{$title.fontset}">
       <xsl:apply-templates select="." mode="chapter.titlepage.recto.mode"/>
     </fo:block>

--- a/suse2013/fo/fonts.ent
+++ b/suse2013/fo/fonts.ent
@@ -16,9 +16,10 @@
 <!ENTITY xxx-small            "6">
 <!ENTITY xx-small             "7">
 <!ENTITY x-small              "8">
-<!ENTITY small                "9">
-<!ENTITY normal               "10">
-<!ENTITY large                "12">
+<!ENTITY small                "9.5">
+<!-- Odd numbers to be bug-compatible with previous versions. -->
+<!ENTITY normal               "11.15">
+<!ENTITY large                "12.5">
 <!ENTITY x-large              "14">
 <!ENTITY xx-large             "16">
 <!ENTITY xxx-large            "20">

--- a/suse2013/fo/glossary.titlepage.templates.xsl
+++ b/suse2013/fo/glossary.titlepage.templates.xsl
@@ -27,7 +27,7 @@
   <xsl:template name="glossary.titlepage.recto">
     <fo:block
       xsl:use-attribute-sets="glossary.titlepage.recto.style"
-      font-size="&super-large;pt" font-family="{$title.fontset}">
+      font-size="{&super-large; * $fontsize-adjust * $sans-xheight-adjust}pt" font-family="{$title.fontset}">
       <xsl:attribute name="margin-{$start-border}">
         <xsl:value-of select="$title.margin.left"/>
       </xsl:attribute>
@@ -58,7 +58,7 @@
   <xsl:template match="title" mode="glossdiv.titlepage.recto.auto.mode">
     <fo:block
       xsl:use-attribute-sets="glossdiv.titlepage.recto.style"
-      font-size="&xxx-large;pt" font-family="{$title.fontset}">
+      font-size="{&xxx-large; * $fontsize-adjust * $sans-xheight-adjust}pt" font-family="{$title.fontset}">
       <xsl:attribute name="margin-{$start-border}">
         <xsl:value-of select="$title.margin.left"/>
       </xsl:attribute>

--- a/suse2013/fo/inline.xsl
+++ b/suse2013/fo/inline.xsl
@@ -125,7 +125,7 @@
   <xsl:param name="mode" select="'normal'"/>
   <xsl:param name="before" select="''"/>
   <xsl:param name="after" select="''"/>
-   <xsl:param name="textcolor" select="'&black;'"/>
+   <xsl:param name="textcolor" select="'inherit'"/>
   <xsl:variable name="mono-verbatim-ancestor">
     <xsl:if test="$mode = 'mono-ancestor' or ancestor::screen or
                   ancestor::programlisting or ancestor::synopsis">1</xsl:if>
@@ -317,9 +317,7 @@
     <xsl:when test="self::command and ancestor::screen">
      <xsl:value-of select="$dark-green"/>
     </xsl:when>
-    <xsl:otherwise>
-     inherit
-    </xsl:otherwise>
+    <xsl:otherwise>inherit</xsl:otherwise>
    </xsl:choose>
   </xsl:param>
 
@@ -403,9 +401,7 @@
     <xsl:when test="self::command and parent::screen">
      <xsl:value-of select="$dark-green"/>
     </xsl:when>
-    <xsl:otherwise>
-     &black;
-    </xsl:otherwise>
+    <xsl:otherwise>inherit</xsl:otherwise>
    </xsl:choose>
   </xsl:param>
   <xsl:call-template name="inline.boldmonoseq">
@@ -582,7 +578,8 @@
   <xsl:param name="count" select="1"/>
   <xsl:param name="color">
     <xsl:choose>
-      <xsl:when test="ancestor::title">&dark-green;</xsl:when>
+      <!-- FIXME: This has the side effect of looking wrong in TOCs. suse-xsl#297 -->
+      <xsl:when test="ancestor::title"><xsl:value-of select="$dark-green"/></xsl:when>
       <xsl:otherwise>&black;</xsl:otherwise>
     </xsl:choose>
   </xsl:param>

--- a/suse2013/fo/inline.xsl
+++ b/suse2013/fo/inline.xsl
@@ -318,7 +318,7 @@
      <xsl:value-of select="$dark-green"/>
     </xsl:when>
     <xsl:otherwise>
-     &black;
+     inherit
     </xsl:otherwise>
    </xsl:choose>
   </xsl:param>

--- a/suse2013/fo/l10n.properties.xml
+++ b/suse2013/fo/l10n.properties.xml
@@ -278,7 +278,7 @@
          "ugly" and "originating from a person of low integrity",
          apparently. -->
     <prop name="enable-italic">false</prop>
-    <prop name="fontsize-adjust">1</prop>
+    <prop name="fontsize-adjust">1.1</prop>
     <prop name="sans-xheight-adjust">1</prop>
     <prop name="mono-xheight-adjust">0.781</prop>
     <prop name="base-lineheight">1.5</prop>

--- a/suse2013/fo/l10n.properties.xml
+++ b/suse2013/fo/l10n.properties.xml
@@ -201,7 +201,7 @@
     <!-- dummy values... -->
     <prop name="sans-lineheight-adjust" ref-lang="default"/>
     <prop name="mono-lineheight-adjust" ref-lang="default"/>
-    <prop name="sans-cutoff-factor">0.75</prop>
+    <prop name="sans-cutoff-factor">0.85</prop>
     <prop name="enable-text-justification">false</prop>
     <prop name="writing-mode" ref-lang="default"/>
   </lang>
@@ -222,7 +222,7 @@
     <prop name="sans-lineheight-adjust">1</prop>
     <prop name="mono-lineheight-adjust" ref-lang="default"/>
     <!-- cutoff factor untested -->
-    <prop name="sans-cutoff-factor">0.75</prop>
+    <prop name="sans-cutoff-factor">0.85</prop>
     <prop name="enable-text-justification">false</prop>
     <prop name="writing-mode" ref-lang="default"/>
   </lang>
@@ -248,7 +248,7 @@
     <prop name="sans-lineheight-adjust">1</prop>
     <prop name="mono-lineheight-adjust">1</prop>
     <!-- cutoff factor untested -->
-    <prop name="sans-cutoff-factor">0.75</prop>
+    <prop name="sans-cutoff-factor">0.85</prop>
     <prop name="enable-text-justification">false</prop>
     <prop name="writing-mode" ref-lang="default"/>
   </lang>
@@ -286,7 +286,7 @@
     <prop name="sans-lineheight-adjust">1</prop>
     <prop name="mono-lineheight-adjust" ref-lang="default"/>
     <!-- cutoff factor untested -->
-    <prop name="sans-cutoff-factor">0.6</prop>
+    <prop name="sans-cutoff-factor">0.75</prop>
     <prop name="enable-text-justification">false</prop>
     <prop name="writing-mode" ref-lang="default"/>
   </lang>

--- a/suse2013/fo/param.xsl
+++ b/suse2013/fo/param.xsl
@@ -301,6 +301,26 @@ task before
   </xsl:call-template>
 </xsl:param>
 
+<!-- Callouts font basically hardcoded to be the default font (since these
+are always just normal numbers). -->
+<xsl:param name="callout-font-stack">
+  <xsl:call-template name="get.l10n.property">
+    <xsl:with-param name="property" select="'sans'"/>
+    <xsl:with-param name="property.language" select="'default'"/>
+  </xsl:call-template>
+</xsl:param>
+<xsl:param name="enable-callout-font-semibold">
+  <xsl:call-template name="get.l10n.property">
+    <xsl:with-param name="property" select="'enable-sans-semibold'"/>
+    <xsl:with-param name="property.language" select="'default'"/>
+  </xsl:call-template>
+</xsl:param>
+<xsl:param name="callout-font-weight">
+  <xsl:choose>
+    <xsl:when test="$enable-callout-font-semibold">600</xsl:when>
+    <xsl:otherwise>700</xsl:otherwise>
+  </xsl:choose>
+</xsl:param>
 
 
 <!-- 24. EBNF =================================================== -->

--- a/suse2013/fo/param.xsl
+++ b/suse2013/fo/param.xsl
@@ -214,9 +214,9 @@ task before
 
 <xsl:param name="body.font.master" select="'&normal;'"/>
 <xsl:param name="body.font.size">
-  <xsl:value-of select="($body.font.master * $fontsize-adjust) div $mono-xheight-adjust"/>pt
+  <xsl:value-of select="$body.font.master * $fontsize-adjust"/>pt
 </xsl:param>
-<xsl:param name="footnote.font.size" select="'&small;pt'"/>
+<xsl:param name="footnote.font.size"><xsl:value-of select="&super-large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:param>
 
 
 <!-- 21. Property Sets ========================================== -->

--- a/suse2013/fo/preface.titlepage.templates.xsl
+++ b/suse2013/fo/preface.titlepage.templates.xsl
@@ -26,7 +26,7 @@
   <xsl:template name="preface.titlepage.recto">
     <fo:block
       xsl:use-attribute-sets="preface.titlepage.recto.style component.title.style"
-      font-size="&super-large;pt" font-family="{$title.fontset}">
+      font-size="{&super-large; * $fontsize-adjust * $sans-xheight-adjust}pt" font-family="{$title.fontset}">
       <xsl:attribute name="margin-{$start-border}">
         <xsl:value-of select="$title.margin.left"/>
       </xsl:attribute>

--- a/suse2013/fo/sections.xsl
+++ b/suse2013/fo/sections.xsl
@@ -189,11 +189,11 @@
 
   <fo:block id="{$id}"
             xsl:use-attribute-sets="section.level1.properties">
-    <fo:block font-size="&small;pt" space-before="1.12em" space-after="0.75em"
+    <fo:block font-size="{&small; * $fontsize-adjust * $sans-xheight-adjust}pt" space-before="1.12em" space-after="0.75em"
        keep-with-next="always" xsl:use-attribute-sets="sans.bold">
       <xsl:value-of select="title" />
     </fo:block>
-    <fo:block font-size="&xxx-small;pt">
+    <fo:block font-size="{&xxx-small; * $fontsize-adjust * $sans-xheight-adjust}pt">
       <xsl:apply-templates/>
     </fo:block>
   </fo:block>
@@ -206,7 +206,7 @@
 
   <fo:block id="{$id}"
             xsl:use-attribute-sets="section.level2.properties">
-    <fo:block font-size="&x-small;pt"
+    <fo:block font-size="{&x-small; * $fontsize-adjust * $sans-xheight-adjust}pt"
       keep-with-next="always"
       space-before="1.12em" space-after="0.5em"
       space-after.precedence="2">
@@ -222,13 +222,13 @@
 
   <fo:block id="{$id}"
             xsl:use-attribute-sets="section.level2.properties">
-    <fo:block font-size="&x-small;pt"
+    <fo:block font-size="{&x-small; * $fontsize-adjust * $sans-xheight-adjust}pt"
       keep-with-next="always"
       space-before="1.12em" space-after="0.5em"
       space-after.precedence="2">
       <xsl:value-of select="title"/>
     </fo:block>
-    <fo:block font-size="&xxx-small;pt">
+    <fo:block font-size="{&xxx-small; * $fontsize-adjust * $sans-xheight-adjust}pt">
       <xsl:apply-templates/>
     </fo:block>
   </fo:block>
@@ -240,11 +240,11 @@
   </xsl:variable>
 
   <fo:block id="{$id}" xsl:use-attribute-sets="section.level3.properties">
-    <fo:block font-size="&x-small;pt" space-before="1.12em" space-after="0.5em"
+    <fo:block font-size="{&x-small; * $fontsize-adjust * $sans-xheight-adjust}pt" space-before="1.12em" space-after="0.5em"
       xsl:use-attribute-sets="italicized.noreplacement">
       <xsl:value-of select="title"/>
     </fo:block>
-    <fo:block font-size="&xxx-small;pt">
+    <fo:block font-size="{&xxx-small; * $fontsize-adjust * $sans-xheight-adjust}pt">
       <xsl:apply-templates/>
     </fo:block>
   </fo:block>
@@ -257,10 +257,10 @@
 
   <fo:block id="{$id}"
             xsl:use-attribute-sets="section.level4.properties">
-    <fo:block font-size="&x-small;pt" font-weight="normal">
+    <fo:block font-size="{&x-small; * $fontsize-adjust * $sans-xheight-adjust}pt" font-weight="normal">
       <xsl:value-of select="title"/>
     </fo:block>
-    <fo:block font-size="&xxx-small;pt">
+    <fo:block font-size="{&xxx-small; * $fontsize-adjust * $sans-xheight-adjust}pt">
       <xsl:apply-templates/>
     </fo:block>
   </fo:block>
@@ -268,7 +268,7 @@
 
 <xsl:template match="screen[ancestor::sect1[@role='legal']]">
   <fo:block xsl:use-attribute-sets="monospace.verbatim.properties shade.verbatim.style"
-            font-size="{&xxx-small; - 1.1}pt"
+            font-size="{(&xxx-small; * $fontsize-adjust * $sans-xheight-adjust) - 1.1}pt"
             white-space-collapse='false'
             white-space-treatment='preserve'
             linefeed-treatment='preserve'>

--- a/suse2013/fo/titlepage.templates.xsl
+++ b/suse2013/fo/titlepage.templates.xsl
@@ -34,7 +34,7 @@
 <!-- Set ==================================================== -->
 <xsl:template match="title" mode="set.titlepage.recto.auto.mode">
   <fo:block xsl:use-attribute-sets="set.titlepage.recto.style"
-    font-size="&ultra-large;pt" space-before="&columnfragment;mm"
+    font-size="{&ultra-large; * $fontsize-adjust * $sans-xheight-adjust}pt" space-before="&columnfragment;mm"
     font-family="{$title.fontset}">
     <xsl:call-template name="division.title">
       <xsl:with-param name="node" select="ancestor-or-self::set[1]"/>
@@ -47,7 +47,7 @@
 <xsl:template match="title" mode="part.titlepage.recto.auto.mode">
   <fo:block
     xsl:use-attribute-sets="part.titlepage.recto.style sans.bold.noreplacement"
-    font-size="&super-large;pt" space-before="&columnfragment;mm"
+    font-size="{&super-large; * $fontsize-adjust * $sans-xheight-adjust}pt" space-before="&columnfragment;mm"
     font-family="{$title.fontset}">
     <xsl:call-template name="division.title">
       <xsl:with-param name="node" select="ancestor-or-self::part[1]"/>
@@ -58,7 +58,7 @@
 <xsl:template match="subtitle" mode="part.titlepage.recto.auto.mode">
   <fo:block
     xsl:use-attribute-sets="part.titlepage.recto.style sans.bold.noreplacement"
-    font-size="&xxx-large;pt" font-style="normal"
+    font-size="{&xxx-large; * $fontsize-adjust * $sans-xheight-adjust}pt" font-style="normal"
     space-before="&gutter;mm" font-family="{$title.fontset}">
     <xsl:apply-templates select="." mode="part.titlepage.recto.mode"/>
   </fo:block>
@@ -87,11 +87,11 @@
       <xsl:choose>
         <xsl:when test="ancestor-or-self::article">
           <xsl:attribute name="space-after">&gutter;mm</xsl:attribute>
-          <xsl:attribute name="font-size">&xxx-large;pt</xsl:attribute>
+          <xsl:attribute name="font-size"><xsl:value-of select="&xxx-large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
         </xsl:when>
         <xsl:when test="ancestor-or-self::book">
           <xsl:attribute name="space-after">&column;mm</xsl:attribute>
-          <xsl:attribute name="font-size">&super-large;pt</xsl:attribute>
+          <xsl:attribute name="font-size"><xsl:value-of select="&super-large; * $fontsize-adjust * $sans-xheight-adjust"/>pt</xsl:attribute>
         </xsl:when>
         <xsl:otherwise/>
       </xsl:choose>

--- a/suse2013/fo/xref.xsl
+++ b/suse2013/fo/xref.xsl
@@ -185,7 +185,7 @@
           select="$target.chapandapp/@id"/>') with a different language than the main book.</xsl:message>
       </xsl:if>
 
-      <fo:inline xsl:use-attribute-sets="italicized">
+      <fo:inline xsl:use-attribute-sets="xref.basic.properties">
         <xsl:call-template name="create.linkto.other.book">
           <xsl:with-param name="target" select="$target"/>
           <xsl:with-param name="lang" select="$lang"/>

--- a/tests/dapscompare-tests/db4-reference/DC-art
+++ b/tests/dapscompare-tests/db4-reference/DC-art
@@ -1,5 +1,5 @@
 ## Basics
-MAIN="test.xml"
+MAIN="main.xml"
 ROOTID="cha.reference"
 
 ## Profiling

--- a/tests/dapscompare-tests/db4-reference/xml/external.xml
+++ b/tests/dapscompare-tests/db4-reference/xml/external.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet
+ href="urn:x-daps:xslt:profiling:docbook45-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.docbook.org/xml/4.5/docbookx.dtd"
+[
+
+]>
+<book lang="en" id="book.external">
+ <title>Foo Bar in the Fooish Bar</title>
+ <bookinfo>
+  <productname>Long Long Name Name</productname>
+  <productname role="abbrev">Shortname</productname>
+  <productnumber>93/4</productnumber>
+  <authorgroup>
+   <author>
+    <firstname>Linda</firstname>
+    <surname>McLane</surname>
+   </author>
+   <author>
+    <firstname>Lance</firstname>
+    <surname>McLorne</surname>
+   </author>
+   <author>
+    <firstname>Ludvig</firstname>
+    <surname>McLence</surname>
+   </author>
+  </authorgroup>
+  <date>2016-10-31</date>
+ </bookinfo>
+
+ <chapter id="cha.external">
+  <title>External References</title>
+  <para>
+   Truffaut prism pinterest, biodiesel ethical schlitz etsy blog. Venmo
+   salvia shabby chic ramps tofu microdosing.
+  </para>
+  <sect1 id="sec.external.more-reference">
+   <title>More References</title>
+   <para>
+    Butcher chicharrones lyft, asymmetrical copper mug jianbing etsy af next
+    level banh mi man bun. Photo booth pork belly pug migas, irony mumblecore
+    green juice hot chicken hashtag DIY PBR&amp;B pour-over.
+   </para>
+   <sect2 id="sec.external.reference.literal">
+    <title>With a Literal Like <literal>la croix</literal></title>
+    <para>
+     Man braid fashion axe typewriter.
+    </para>
+   </sect2>
+   <sect2 id="sec.external.reference.command">
+    <title>With a Command Like <command>mixtape</command></title>
+    <para>
+     Everyday carry bespoke cornhole sartorial bitters.
+    </para>
+   </sect2>
+   <sect2 id="sec.external.reference.guimenu">
+    <title>With a Guimenu Like <guimenu>Irony Mumblecore Green</guimenu></title>
+    <para>
+     Kinfolk hella freegan cliche.
+    </para>
+   </sect2>
+   <sect2 id="sec.external.reference.menuchoice">
+    <title>With a Menuchoice Like <menuchoice><guimenu>Irony</guimenu><guimenu>Mumblecore</guimenu><guimenu>Green</guimenu></menuchoice></title>
+    <para>
+     Readymade listicle kale chips drinking vinegar.
+    </para>
+   </sect2>
+  </sect1>
+ </chapter>
+</book>

--- a/tests/dapscompare-tests/db4-reference/xml/main.xml
+++ b/tests/dapscompare-tests/db4-reference/xml/main.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet
+ href="urn:x-daps:xslt:profiling:docbook45-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE set PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.docbook.org/xml/4.5/docbookx.dtd"
+[
+
+]>
+<set lang="en" id="set.foo">
+ <title>Set</title>
+ <setinfo>
+  <productname>Long Long Name Name</productname>
+  <productname role="abbrev">Shortname</productname>
+  <productnumber>93/4</productnumber>
+  <authorgroup>
+   <author>
+    <firstname>Linda</firstname>
+    <surname>McLane</surname>
+   </author>
+   <author>
+    <firstname>Lance</firstname>
+    <surname>McLorne</surname>
+   </author>
+   <author>
+    <firstname>Ludvig</firstname>
+    <surname>McLence</surname>
+   </author>
+  </authorgroup>
+  <date>2016-10-31</date>
+ </setinfo>
+ <xi:include href="test.xml" parse="xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+ <xi:include href="external.xml" parse="xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+</set>

--- a/tests/dapscompare-tests/db4-reference/xml/test.xml
+++ b/tests/dapscompare-tests/db4-reference/xml/test.xml
@@ -38,8 +38,107 @@
    microdosing</ulink>.
   </para>
   <para>
+   Letterpress kale chips seitan bushwick meh sustainable selfies offal fanny
+   pack mustache <ulink url="https://www.opensuse.org"/>.
+  </para>
+  <para>
    Godard blue bottle fam hell of, vegan hoodie swag DIY ennui forage pop-up:
    <xref linkend="cha.reference"/>.
   </para>
+  <para>
+    Tote bag plaid
+    banjo, schlitz tacos fashion axe live-edge gentrify salvia bicycle rights
+    disrupt selfies freegan vegan:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     Asymmetrical copper mug: <xref linkend="sec.reference.literal"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Ethical coloring book: <xref linkend="sec.reference.command"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     VHS fixie flannel: <xref linkend="sec.reference.guimenu"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Gochujang activated charcoal: <xref linkend="sec.reference.menuchoice"/>
+    </para>
+   </listitem>
+  </itemizedlist>
+  <para>
+   Keffiyeh vexillologist aesthetic bag plaid banjo, schlitz tacos fashion
+   axe live-edge:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     Asymmetrical copper mug: <xref linkend="cha.external"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Ethical coloring book: <xref linkend="sec.external.more-reference"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     VHS fixie flannel: <xref linkend="sec.external.reference.literal"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Shabby chic tattooed cornhole: <xref linkend="sec.external.reference.command"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Wayfarers tote bag: <xref linkend="sec.external.reference.guimenu"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Readymade kale chips drinking vinegar: <xref linkend="sec.external.reference.menuchoice"/>
+    </para>
+   </listitem>
+  </itemizedlist>
+  <sect1 id="sec.more-reference">
+   <title>More References</title>
+   <para>
+    Butcher chicharrones lyft, asymmetrical copper mug jianbing etsy af next
+    level banh mi man bun. Photo booth pork belly pug migas, irony mumblecore
+    green juice hot chicken hashtag DIY PBR&amp;B pour-over.
+   </para>
+   <sect2 id="sec.reference.literal">
+    <title>With a Literal Like <literal>la croix</literal></title>
+    <para>
+     Man braid fashion axe typewriter.
+    </para>
+   </sect2>
+   <sect2 id="sec.reference.command">
+    <title>With a Command Like <command>mixtape</command></title>
+    <para>
+     Everyday carry bespoke cornhole sartorial bitters.
+    </para>
+   </sect2>
+   <sect2 id="sec.reference.guimenu">
+    <title>With a Guimenu Like <guimenu>Irony Mumblecore Green</guimenu></title>
+    <para>
+     Kinfolk hella freegan cliche.
+    </para>
+   </sect2>
+   <sect2 id="sec.reference.menuchoice">
+    <title>With a Menuchoice Like <menuchoice><guimenu>Irony</guimenu><guimenu>Mumblecore</guimenu><guimenu>Green</guimenu></menuchoice></title>
+    <para>
+     Readymade listicle kale chips drinking vinegar.
+    </para>
+   </sect2>
+  </sect1>
  </chapter>
 </book>

--- a/tests/dapscompare-tests/db5-reference/DC-art
+++ b/tests/dapscompare-tests/db5-reference/DC-art
@@ -1,5 +1,5 @@
 ## Basics
-MAIN="test.xml"
+MAIN="main.xml"
 ROOTID="cha.reference"
 
 ## Profiling

--- a/tests/dapscompare-tests/db5-reference/xml/external.xml
+++ b/tests/dapscompare-tests/db5-reference/xml/external.xml
@@ -6,11 +6,11 @@
 [
 ]>
 
-<book xml:lang="en" xml:id="book.foo"
+<book xml:lang="en" xml:id="book.external"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Foo Bar in the Fooish Bar DB5</title>
+ <title>Another Book</title>
  <info>
   <productname>Long Long Name Name</productname>
   <productname role="abbrev">Shortname</productname>
@@ -48,109 +48,38 @@
   </abstract>
  </info>
 
- <chapter xml:id="cha.reference">
-  <title>References</title>
+ <chapter xml:id="cha.external">
+  <title>External References</title>
   <para>
    Truffaut prism pinterest, biodiesel ethical schlitz etsy blog. Venmo
-   salvia shabby chic ramps <link xlink:href="https://www.opensuse.org">tofu
-   microdosing</link>.
+   salvia shabby chic ramps tofu microdosing.
   </para>
-  <para>
-   Letterpress kale chips seitan bushwick meh sustainable selfies offal fanny
-   pack mustache <link xlink:href="https://www.opensuse.org"/>.
-  </para>
-  <para>
-   Godard blue bottle fam hell of, vegan hoodie swag DIY ennui forage pop-up:
-   <xref linkend="cha.reference"/>.
-  </para>
-  <para>
-   Tote bag plaid banjo, schlitz tacos fashion axe live-edge gentrify salvia
-   bicycle rights disrupt selfies freegan vegan:
-  </para>
-  <itemizedlist>
-   <listitem>
-    <para>
-     Asymmetrical copper mug: <xref linkend="sec.reference.literal"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Ethical coloring book: <xref linkend="sec.reference.command"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     VHS fixie flannel: <xref linkend="sec.reference.guimenu"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Gochujang activated charcoal: <xref linkend="sec.reference.menuchoice"/>
-    </para>
-   </listitem>
-  </itemizedlist>
-  <para>
-   Keffiyeh vexillologist aesthetic bag plaid banjo, schlitz tacos fashion
-   axe live-edge:
-  </para>
-  <itemizedlist>
-   <listitem>
-    <para>
-     Asymmetrical copper mug: <xref linkend="cha.external"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Ethical coloring book: <xref linkend="sec.external.more-reference"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     VHS fixie flannel: <xref linkend="sec.external.reference.literal"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Shabby chic tattooed cornhole: <xref linkend="sec.external.reference.command"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Wayfarers tote bag: <xref linkend="sec.external.reference.guimenu"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Readymade kale chips drinking vinegar: <xref linkend="sec.external.reference.menuchoice"/>
-    </para>
-   </listitem>
-  </itemizedlist>
-  <sect1 xml:id="sec.more-reference">
+  <sect1 xml:id="sec.external.more-reference">
    <title>More References</title>
    <para>
     Butcher chicharrones lyft, asymmetrical copper mug jianbing etsy af next
     level banh mi man bun. Photo booth pork belly pug migas, irony mumblecore
     green juice hot chicken hashtag DIY PBR&amp;B pour-over.
    </para>
-   <sect2 xml:id="sec.reference.literal">
+   <sect2 xml:id="sec.external.reference.literal">
     <title>With a Literal Like <literal>la croix</literal></title>
     <para>
      Man braid fashion axe typewriter.
     </para>
    </sect2>
-   <sect2 xml:id="sec.reference.command">
+   <sect2 xml:id="sec.external.reference.command">
     <title>With a Command Like <command>mixtape</command></title>
     <para>
      Everyday carry bespoke cornhole sartorial bitters.
     </para>
    </sect2>
-   <sect2 xml:id="sec.reference.guimenu">
+   <sect2 xml:id="sec.external.reference.guimenu">
     <title>With a Guimenu Like <guimenu>Irony Mumblecore Green</guimenu></title>
     <para>
      Kinfolk hella freegan cliche.
     </para>
    </sect2>
-   <sect2 xml:id="sec.reference.menuchoice">
+   <sect2 xml:id="sec.external.reference.menuchoice">
     <title>With a Menuchoice Like <menuchoice><guimenu>Irony</guimenu><guimenu>Mumblecore</guimenu><guimenu>Green</guimenu></menuchoice></title>
     <para>
      Readymade listicle kale chips drinking vinegar.

--- a/tests/dapscompare-tests/db5-reference/xml/main.xml
+++ b/tests/dapscompare-tests/db5-reference/xml/main.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook50-profile.xsl"
+                 type="text/xml"
+                 title="Profiling step"?>
+<!DOCTYPE set
+[
+]>
+<set xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en" xml:id="set.foo">
+ <title>Set</title>
+ <info>
+  <productname>Long Long Name Name</productname>
+  <productname role="abbrev">Shortname</productname>
+  <productnumber>93/4</productnumber>
+  <authorgroup>
+   <author>
+    <personname>
+     <firstname>Linda</firstname>
+     <surname>McLane</surname>
+    </personname>
+   </author>
+   <author>
+    <personname>
+     <firstname>Lance</firstname>
+     <surname>McLorne</surname>
+    </personname>
+   </author>
+   <author>
+    <personname>
+     <firstname>Ludvig</firstname>
+     <surname>McLence</surname>
+    </personname>
+   </author>
+  </authorgroup>
+  <date>2016-10-31</date>
+ </info>
+ <xi:include href="test.xml" parse="xml"/>
+ <xi:include href="external.xml" parse="xml"/>
+</set>


### PR DESCRIPTION
We never properly used our text scaling possibilities. Text scaling is helpful for languages with very complicated characters (like zh_TW, and to a lesser extent also ja and zh_CN) that might not be properly readable with a Western font size.

So far, it does appear, we only enabled text scaling for some aspects of our documents, now most everything should be covered, as you can see when setting e.g. `<prop name="fontsize-adjust">2</prop>` for "default" in `l10n.properties.xml`. (This should set font sizes to double the normal values [a somewhat extreme example].)

For e1693db, it would be interesting to see if this works for FOP 1.1 users too.