### PR TITLE
Exclude "drupal" and "db2mediawiki"

### DIFF
--- a/packaging/exclude-files_for_susexsl_package.txt
+++ b/packaging/exclude-files_for_susexsl_package.txt
@@ -8,6 +8,10 @@ fonts/*.sfd
 packaging
 packaging/*
 set-version.sh
+suse/db2mediawiki
+suse/db2mediawiki/*
+suse/drupal
+suse/drupal/*
 tests
 tests/*
 .git


### PR DESCRIPTION
This fixes #310, tested with `make dist`.