### PR TITLE
First attempt to check for maximum screen length

### DIFF
--- a/suse2013/common/screen-length.xsl
+++ b/suse2013/common/screen-length.xsl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Purpose:
+    Check length of screen content
+
+  Author:     Thomas Schraitle <toms@suse.de>
+  Copyright:  2017 Thomas Schraitle
+
+-->
+<xsl:stylesheet exclude-result-prefixes="exsl str" version="1.0"
+  xmlns:exsl="http://exslt.org/common"
+  xmlns:str="http://exslt.org/strings"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <!-- Maximum preferred screen length of a string before line break -->
+  <xsl:param name="screen.max.length" select="80"/>
+
+
+  <xsl:template name="splitscreen">
+    <xsl:param name="text" select="string(.)"/>
+
+    <xsl:choose>
+      <xsl:when test="contains($text, '&#10;')">
+        <xsl:variable name="text-before-first-break">
+          <xsl:value-of select="substring-before($text, '&#10;')"/>
+        </xsl:variable>
+        <xsl:variable name="text-after-first-break">
+          <xsl:value-of select="substring-after($text, '&#10;')"/>
+        </xsl:variable>
+
+        <xsl:if test="string-length($text-before-first-break) >
+                      $screen.max.length">1</xsl:if>
+
+        <xsl:if test="not($text-after-first-break = '')">
+          <xsl:call-template name="splitscreen">
+            <xsl:with-param name="text" select="$text-after-first-break"/>
+          </xsl:call-template>
+        </xsl:if>
+      </xsl:when>
+      <xsl:when test="string-length($text) > $screen.max.length">1</xsl:when>
+      <xsl:otherwise>0</xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+
+  <xsl:template name="check.screenlength">
+    <!-- Transform everything inside <screen> or <programlisting> into a
+         string, regardless if there are other child elements or not.
+    -->
+    <xsl:param name="text" select="string(.)"/>
+    <!-- Variable "result" contains only "0" or "1", wheather the string
+         is longer or shorter than $screen.max.length
+    -->
+    <xsl:variable name="result">
+      <xsl:call-template name="splitscreen">
+        <xsl:with-param name="text" select="$text"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <!-- Apply it only to programlisting and screen -->
+    <xsl:if test="(self::programlisting or self::screen) and number($result) > 0">
+      <xsl:call-template name="log.message">
+        <xsl:with-param name="level">Warn</xsl:with-param>
+        <xsl:with-param name="source">
+          <xsl:call-template name="xpath.location"/>
+        </xsl:with-param>
+        <xsl:with-param name="context-desc">screen</xsl:with-param>
+        <xsl:with-param name="message">String in screen is longer than <xsl:value-of
+          select="$screen.max.length"/> characters.</xsl:with-param>
+      </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/suse2013/common/screen-length.xsl
+++ b/suse2013/common/screen-length.xsl
@@ -62,7 +62,9 @@
       <xsl:call-template name="log.message">
         <xsl:with-param name="level">Warn</xsl:with-param>
         <xsl:with-param name="source">
-          <xsl:call-template name="xpath.location"/>
+          <xsl:value-of select="local-name(.)"/>
+          <xsl:text> in </xsl:text>
+          <xsl:value-of select="(./ancestor-or-self::*/@id|./ancestor-or-self::*/@xml:id)[last()]"/>
         </xsl:with-param>
         <xsl:with-param name="context-desc">screen</xsl:with-param>
         <xsl:with-param name="message">String in screen is longer than <xsl:value-of

--- a/suse2013/fo/docbook.xsl
+++ b/suse2013/fo/docbook.xsl
@@ -45,6 +45,7 @@
   <xsl:include href="../common/l10n.xsl"/>
   <xsl:include href="../common/xref.xsl"/>
   <xsl:include href="../common/converter-string.xsl"/>
+  <xsl:include href="../common/screen-length.xsl"/>
 
   <xsl:include href="autotoc.xsl"/>
   <xsl:include href="callout.xsl"/>

--- a/suse2013/fo/programlisting.screen.synopsis.xsl
+++ b/suse2013/fo/programlisting.screen.synopsis.xsl
@@ -9,6 +9,8 @@
   <xsl:param name="suppress-numbers" select="'0'"/>
   <xsl:variable name="id"><xsl:call-template name="object.id"/></xsl:variable>
 
+  <xsl:call-template name="check.screenlength"/>
+
   <xsl:variable name="content">
     <xsl:choose>
       <xsl:when test="$suppress-numbers = '0'

--- a/suse2013/xhtml/docbook.xsl
+++ b/suse2013/xhtml/docbook.xsl
@@ -43,6 +43,7 @@
   <xsl:include href="../common/xref.xsl"/>
   <xsl:include href="../common/trim-verbatim.xsl"/>
   <xsl:include href="../common/converter-string.xsl"/>
+  <xsl:include href="../common/screen-length.xsl"/>
 
   <xsl:include href="param.xsl"/>
   <xsl:include href="create-permalink.xsl"/>

--- a/suse2013/xhtml/verbatim.xsl
+++ b/suse2013/xhtml/verbatim.xsl
@@ -18,6 +18,8 @@
   <xsl:variable name="supported" select="concat('|', $highlight.supported.languages, '|')"/>
   <xsl:variable name="language" select="translate(normalize-space(@language), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ|', 'abcdefghijklmnopqrstuvwxyz')"/>
 
+  <xsl:call-template name="check.screenlength"/>
+
   <div>
     <xsl:attribute name="class">
       <xsl:text>verbatim-wrap</xsl:text>


### PR DESCRIPTION
* Check line length inside screen if it exceeds a maximum length
* Takes into account child elements of screen
* Supported in FO and XHTML
* Related to openSUSE/suse-doc-style-checker#162

@sknorr Could you review it? Not sure if we should integrate it. Maybe it's better related to the stylechecker project. On the other side, you get an early warning if the screen content exceeds a maximum length.

Currently, it seems the `screen` template is called twice (I haven't found why) which leads to double warning messages. 🙄 