### PR TITLE
Use dotted style for code-like text

### DIFF
--- a/suse2013/static/css/style.css
+++ b/suse2013/static/css/style.css
@@ -1782,6 +1782,7 @@ code, .command, .keycap, .replaceable, .package {
     font-weight: normal;
     padding: 0 4px;
     border-bottom: 1px solid #C1C1C3;
+    border-bottom-style: dotted;
     color: #333;
     text-transform: none;
     display: inline-block;


### PR DESCRIPTION
Use a non-intrusive dotted line for code-like text.