### PR TITLE
Fix #323: don't generate "book" in intra-xrefs

### DIFF
--- a/suse2013/common/l10n/ar.xml
+++ b/suse2013/common/l10n/ar.xml
@@ -57,7 +57,7 @@ translators apparently want those. - sknorr, 2016-09-30 -->
            It seems "ال" == "the", but I still was not sure whether to add this
            everywhere. I just took the translations from the DocBook
            stylesheets. Expect issues to crop up. -->
-
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text='مقال "%t"'/>
       <l:template name="intra-book" text='كتاب "%t"'/>
       <l:template name="intra-chapter" text='فصل&#160;%n "%t"'/>

--- a/suse2013/common/l10n/cs.xml
+++ b/suse2013/common/l10n/cs.xml
@@ -67,6 +67,7 @@
       <l:template name="sect5" text="&#268;&#225;st &#8222;%t&#8220;"/>
       <l:template name="page.citation" text=" (strana&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Článek „%t”"/>
       <l:template name="intra-book" text="Kniha „%t”"/>
       <l:template name="intra-chapter" text="Kapitola&#160;%n „%t”"/>

--- a/suse2013/common/l10n/da.xml
+++ b/suse2013/common/l10n/da.xml
@@ -77,6 +77,7 @@
       <l:template name="sect5" text="Afsnit &#34;%t&#34;"/>
       <l:template name="page.citation" text=" (side&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikel “%t” "/>
       <l:template name="intra-book" text="Bog “%t” "/>
       <l:template name="intra-chapter" text="Kapitel&#160;%n “%t”"/>

--- a/suse2013/common/l10n/de.xml
+++ b/suse2013/common/l10n/de.xml
@@ -71,6 +71,7 @@
    <l:context name="xref">
       <l:template name="page.citation" text=" (S.&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikel „%t”"/>
       <l:template name="intra-book" text="Buch „%t”"/>
       <l:template name="intra-chapter" text="Kapitel %n „%t”"/>

--- a/suse2013/common/l10n/en.xml
+++ b/suse2013/common/l10n/en.xml
@@ -75,6 +75,7 @@
       <l:template name="sect5" text="Section “%t”"/>
       <l:template name="page.citation" text=" (page&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Article “%t”"/>
       <l:template name="intra-book" text="Book “%t”"/>
       <l:template name="intra-chapter" text="Chapter&#160;%n “%t”"/>

--- a/suse2013/common/l10n/es.xml
+++ b/suse2013/common/l10n/es.xml
@@ -73,7 +73,7 @@
 
    <l:context name="xref">
       <l:template name="page.citation" text=" (p.&#160;%p)"/>
-		  <l:template name="bridgehead" text="Secci&#243;n&#160;&#8220;%t&#8221;"/>
+		    <l:template name="bridgehead" text="Secci&#243;n&#160;&#8220;%t&#8221;"/>
       <l:template name="chapter" text="Cap&#237;tulo&#160;%t"/>
       <l:template name="equation" text="Ecuaci&#243;n&#160;&#8220;%t&#8221;"/>
       <l:template name="example" text="Ejemplo&#160;&#8220;%t&#8221;"/>
@@ -94,6 +94,7 @@
       <l:template name="section" text="Secci&#243;n&#160;&#8220;%t&#8221;"/>
       <l:template name="simplesect" text="secci&#243;n llamada &#8220;%t&#8221;"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artículo “%t”"/>
       <l:template name="intra-book" text="Libro “%t”"/>
       <l:template name="intra-chapter" text="Capítulo&#160;%n “%t”"/>

--- a/suse2013/common/l10n/fi.xml
+++ b/suse2013/common/l10n/fi.xml
@@ -69,6 +69,7 @@
       <l:template name="sect5" text="Osa ”%t”"/>
       <l:template name="page.citation" text=" (sivu&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikkeli ”%t”"/>
       <l:template name="intra-book" text="Kirja ”%t”"/>
       <l:template name="intra-chapter" text="Luku&#160;%n ”%t”"/>

--- a/suse2013/common/l10n/fr.xml
+++ b/suse2013/common/l10n/fr.xml
@@ -75,6 +75,7 @@
    <l:context name="xref">
       <l:template name="page.citation" text=" (p.&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Article «&#160;%t&#160;»"/>
       <l:template name="intra-book" text="Manuel «&#160;%t&#160;»"/>
       <l:template name="intra-chapter" text="Chapitre %n «&#160;%t&#160;»"/>

--- a/suse2013/common/l10n/hu.xml
+++ b/suse2013/common/l10n/hu.xml
@@ -79,6 +79,7 @@
       <!-- Linguist said that the inclusion of the word for book does not work
       in HU and suggests removing it because it is obviously an
       external book name. -->
+      <l:template name="intra-separator" text=", "/>
       <!--<l:template name="intra-book" text="könyv „%t”"/>-->
       <l:template name="intra-book" text="„%t”"/>
       <l:template name="intra-chapter" text="%n.&#160;fejezet (%t)"/>

--- a/suse2013/common/l10n/it.xml
+++ b/suse2013/common/l10n/it.xml
@@ -81,6 +81,7 @@
       <l:template name="section" text="Sezione «%t»"/>
       <l:template name="simplesect" text="Sezione «%t»"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Articolo «%t»"/>
       <l:template name="intra-book" text="Libro «%t»"/>
       <l:template name="intra-chapter" text="Capitolo %n «%t»"/>

--- a/suse2013/common/l10n/ja.xml
+++ b/suse2013/common/l10n/ja.xml
@@ -63,13 +63,14 @@
    <l:context name="xref">
     <l:template name="page.citation" text=" (%p&#160;&#12506;&#12540;&#12472;)"/>
 
+    <l:template name="intra-separator" text="、 "/>
     <l:template name="intra-article" text="項目 「%t」"/>
-    <l:template name="intra-book" text="ブック 『%t』"/>
-    <l:template name="intra-chapter" text="章 %n 「%t」"/>
-    <l:template name="intra-sect1" text="項&#160;%n 「%t」"/>
-    <l:template name="intra-sect2" text="項&#160;%n 「%t」"/>
-    <l:template name="intra-sect3" text="項&#160;%n 「%t」"/>
-    <l:template name="intra-sect4" text="項&#160;%n 「%t」"/>
+    <l:template name="intra-book" text="『%t』"/>
+    <l:template name="intra-chapter" text="「%t」の章"/>
+    <l:template name="intra-sect1" text="のセクション「%t」"/>
+    <l:template name="intra-sect2" text="のセクション「%t」"/>
+    <l:template name="intra-sect3" text="のセクション「%t」"/>
+    <l:template name="intra-sect4" text="のセクション「%t」"/>
 
     <l:template name="intra-example" text="&#160;%n 「%t」"/>
     <l:template name="intra-figure" text="図&#160;%n 「%t」"/>

--- a/suse2013/common/l10n/ko.xml
+++ b/suse2013/common/l10n/ko.xml
@@ -70,6 +70,7 @@
    <l:context name="xref">
       <l:template name="page.citation" text="%p&#54168;&#51060;&#51648; "/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="문서 “%t”"/>
       <l:template name="intra-book" text="책 “%t”"/>
       <l:template name="intra-chapter" text="%n장 “%t”"/>

--- a/suse2013/common/l10n/lt_lt.xml
+++ b/suse2013/common/l10n/lt_lt.xml
@@ -72,6 +72,7 @@
       <l:template name="sect5" text="„%t“"/>
       <l:template name="page.citation" text=" (p.&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Straipsnis „%t“"/>
       <l:template name="intra-book" text="Knyga „%t“"/>
       <l:template name="intra-chapter" text="Skyrius&#160;%n „%t“"/>

--- a/suse2013/common/l10n/nl.xml
+++ b/suse2013/common/l10n/nl.xml
@@ -80,6 +80,7 @@
       <l:template name="sect5" text="Gedeelte “%t”"/>
       <l:template name="page.citation" text=" (pagina&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikel “%t”"/>
       <l:template name="intra-book" text="Boek “%t” "/>
       <l:template name="intra-chapter" text="Hoofdstuk&#160;%n “%t”"/>

--- a/suse2013/common/l10n/no.xml
+++ b/suse2013/common/l10n/no.xml
@@ -69,6 +69,7 @@
       <l:template name="sect5" text="Del «%t»"/>
       <l:template name="page.citation" text=" (side&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikkel «%t»"/>
       <l:template name="intra-book" text="Bok «%t» "/>
       <l:template name="intra-chapter" text="Kapittel&#160;%n «%t»"/>

--- a/suse2013/common/l10n/pl.xml
+++ b/suse2013/common/l10n/pl.xml
@@ -71,6 +71,7 @@
       <l:template name="sect5" text="Sekcja „%t”"/>
       <l:template name="page.citation" text=" (page&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artykuł „%t”"/>
       <l:template name="intra-book" text="Książka „%t”"/>
       <l:template name="intra-chapter" text="Rozdział %n „%t”"/>

--- a/suse2013/common/l10n/pt_br.xml
+++ b/suse2013/common/l10n/pt_br.xml
@@ -70,6 +70,7 @@
    <l:context name="xref">
       <l:template name="page.citation" text=" (p&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artigo “%t”"/>
       <l:template name="intra-book" text="Livro “%t”"/>
       <l:template name="intra-chapter" text="Capítulo %n “%t”"/>

--- a/suse2013/common/l10n/ru.xml
+++ b/suse2013/common/l10n/ru.xml
@@ -69,6 +69,7 @@
    <l:context name="xref">
       <l:template name="page.citation" text=" (стр.&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Статья «%t»"/>
       <l:template name="intra-book" text="Книга «%t»"/>
       <l:template name="intra-chapter" text="Глава %n «%t»"/>

--- a/suse2013/common/l10n/sv.xml
+++ b/suse2013/common/l10n/sv.xml
@@ -73,6 +73,7 @@
       <l:template name="sect5" text="Avsnittet ”%t”"/>
       <l:template name="page.citation" text=" (sidan&#160;%p)"/>
 
+      <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikel ”%t”"/>
       <l:template name="intra-book" text="Bok ”%t”"/>
       <l:template name="intra-chapter" text="Kapitel&#160;%n ”%t”"/>

--- a/suse2013/common/l10n/zh_cn.xml
+++ b/suse2013/common/l10n/zh_cn.xml
@@ -162,7 +162,7 @@
       See also:
       https://en.wikipedia.org/wiki/Quotation_mark#Chinese.2C_Japanese_and_Korean_quotation_marks
      -->
-
+     <l:template name="intra-separator" text=", "/>
      <l:template name="intra-article" text="《%t》文章"/>
      <l:template name="intra-book" text="《%t》"/>
      <l:template name="intra-chapter" text="第&#160;%n 章 “%t”"/>

--- a/suse2013/common/l10n/zh_tw.xml
+++ b/suse2013/common/l10n/zh_tw.xml
@@ -187,6 +187,7 @@
       See also:
       https://en.wikipedia.org/wiki/Quotation_mark#Chinese.2C_Japanese_and_Korean_quotation_marks
      -->
+    <l:template name="intra-separator" text=", "/>
     <l:template name="intra-article" text="《%t》文章"/>
     <l:template name="intra-book" text="《%t》"/>
     <l:template name="intra-chapter" text="第 %n 章「%t」"/>

--- a/suse2013/common/xref.xsl
+++ b/suse2013/common/xref.xsl
@@ -25,6 +25,22 @@
 </xsl:template>
 
 
+<xsl:template name="generate.intra.separator">
+ <xsl:param name="lang"/>
+  <xsl:variable name="comma">
+   <xsl:call-template name="gentext.template">
+    <xsl:with-param name="context" select="'xref'"/>
+    <xsl:with-param name="name"  select="'intra-separator'"/>
+    <xsl:with-param name="lang" select="$lang"/>
+   </xsl:call-template>
+  </xsl:variable>
+
+  <xsl:choose>
+   <xsl:when test="$comma != ''"><xsl:value-of select="$comma"/></xsl:when>
+   <xsl:otherwise><xsl:text>, </xsl:text></xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
 <xsl:template name="create.linkto.other.book">
   <xsl:param name="target"/>
   <!-- It seems we can't get any useful value here anyway, so lets trust the
@@ -41,7 +57,6 @@
       <xsl:with-param name="lang" select="$lang-normalized"/>
     </xsl:apply-templates>
   </xsl:variable>
-
   <xsl:copy-of select="$text"/>
 </xsl:template>
 
@@ -53,7 +68,9 @@
     <xsl:apply-templates select="parent::*" mode="intra.title.markup">
       <xsl:with-param name="lang" select="$lang"/>
     </xsl:apply-templates>
-    <xsl:text>, </xsl:text>
+    <xsl:call-template name="generate.intra.separator">
+     <xsl:with-param name="lang" select="$lang"/>
+    </xsl:call-template>
     <xsl:call-template name="substitute-markup">
       <xsl:with-param name="template">
         <xsl:call-template name="gentext.template">
@@ -76,7 +93,9 @@
       mode="intra.title.markup">
       <xsl:with-param name="lang" select="$lang"/>
     </xsl:apply-templates>
-    <xsl:text>, </xsl:text>
+    <xsl:call-template name="generate.intra.separator">
+     <xsl:with-param name="lang" select="$lang"/>
+    </xsl:call-template>
     <xsl:call-template name="substitute-markup">
       <xsl:with-param name="template">
         <xsl:call-template name="gentext.template">
@@ -97,7 +116,9 @@
     <xsl:apply-templates select="ancestor::book" mode="intra.title.markup">
       <xsl:with-param name="lang" select="$lang"/>
     </xsl:apply-templates>
-    <xsl:text>, </xsl:text>
+    <xsl:call-template name="generate.intra.separator">
+     <xsl:with-param name="lang" select="$lang"/>
+    </xsl:call-template>
     <xsl:call-template name="substitute-markup">
       <xsl:with-param name="template">
         <xsl:call-template name="gentext.template">
@@ -118,7 +139,9 @@
       <xsl:with-param name="lang" select="$lang"/>
     </xsl:apply-templates>
 
-    <xsl:text>, </xsl:text>
+    <xsl:call-template name="generate.intra.separator">
+     <xsl:with-param name="lang" select="$lang"/>
+    </xsl:call-template>
     <xsl:call-template name="substitute-markup">
       <xsl:with-param name="template">
         <xsl:call-template name="gentext.template">
@@ -155,7 +178,6 @@
         </xsl:call-template>
       </xsl:with-param>
     </xsl:call-template>
-
   </xsl:template>
 
 
@@ -172,7 +194,9 @@
     </xsl:apply-templates>
     <xsl:choose>
       <xsl:when test="title">
-        <xsl:text>, </xsl:text>
+        <xsl:call-template name="generate.intra.separator">
+         <xsl:with-param name="lang" select="$lang"/>
+        </xsl:call-template>
         <xsl:apply-templates select="." mode="title.markup">
           <xsl:with-param name="lang" select="$lang"/>
         </xsl:apply-templates>
@@ -182,7 +206,6 @@
         <xsl:message>- affected ID: <xsl:value-of select="(./@id|./@xml:id)[last()]"/></xsl:message>
       </xsl:otherwise>
     </xsl:choose>
-
   </xsl:template>
 
 


### PR DESCRIPTION
* Japanese prefer not to have the word "book" in intra-xrefs

Only one part is solved (the removal of the Japanese word "book"). The second part (use Japanese comma) needs a bit more work as it is used and hard-coded in the template.