### PR TITLE
Fix validation error found by jing/xslt10.rnc

### DIFF
--- a/suse2013/fo/admon.xsl
+++ b/suse2013/fo/admon.xsl
@@ -109,10 +109,43 @@
       <xsl:otherwise>8</xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
-  <xsl:variable name="additional.title.properties">
+  <xsl:variable name="compact.or.normal.block">
+   <!-- This is ugly, but I don't know of any better solution... :-( -->
     <xsl:choose>
-      <xsl:when test="@role='compact'">admonition.compact.title.properties</xsl:when>
-      <xsl:otherwise>admonition.normal.title.properties</xsl:otherwise>
+      <xsl:when test="@role='compact'">
+       <fo:block
+        xsl:use-attribute-sets="admonition.title.properties admonition.compact.title.properties">
+        <xsl:attribute name="color">
+         <xsl:choose>
+          <xsl:when test="not(@role = 'compact')">
+           <xsl:value-of select="$color"/>
+          </xsl:when>
+          <xsl:otherwise>&darker-gray;</xsl:otherwise>
+         </xsl:choose>
+        </xsl:attribute>
+        <xsl:value-of select="@role"/>
+        <xsl:apply-templates select="." mode="object.title.markup">
+         <xsl:with-param name="allow-anchors" select="1"/>
+        </xsl:apply-templates>
+       </fo:block>
+      </xsl:when>
+      <xsl:otherwise>
+       <fo:block
+        xsl:use-attribute-sets="admonition.title.properties admonition.normal.title.properties">
+        <xsl:attribute name="color">
+         <xsl:choose>
+          <xsl:when test="not(@role = 'compact')">
+           <xsl:value-of select="$color"/>
+          </xsl:when>
+          <xsl:otherwise>&darker-gray;</xsl:otherwise>
+         </xsl:choose>
+        </xsl:attribute>
+        <xsl:value-of select="@role"/>
+        <xsl:apply-templates select="." mode="object.title.markup">
+         <xsl:with-param name="allow-anchors" select="1"/>
+        </xsl:apply-templates>
+       </fo:block>
+      </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
   <xsl:variable name="padding">
@@ -140,20 +173,7 @@
             <fo:block padding-start="{(&gutter; - 0.75) div 2}mm"
               padding-before="{$padding}" padding-after="{$padding}">
               <xsl:if test="((title or info/title) or ($admon.textlabel != 0 and not(@role='compact')))">
-                <fo:block xsl:use-attribute-sets="admonition.title.properties {$additional.title.properties}">
-                  <xsl:attribute name="color">
-                    <xsl:choose>
-                      <xsl:when test="not(@role='compact')">
-                        <xsl:value-of select="$color"/>
-                      </xsl:when>
-                      <xsl:otherwise>&darker-gray;</xsl:otherwise>
-                    </xsl:choose>
-                  </xsl:attribute>
-                  <xsl:value-of select="@role"/>
-                  <xsl:apply-templates select="." mode="object.title.markup">
-                    <xsl:with-param name="allow-anchors" select="1"/>
-                  </xsl:apply-templates>
-                </fo:block>
+                <xsl:copy-of select="$compact.or.normal.block"/>
               </xsl:if>
               <fo:block xsl:use-attribute-sets="admonition.properties">
                 <xsl:apply-templates/>


### PR DESCRIPTION
Problem was:

```
suse2013/fo/admon.xsl:143:111: error: value of attribute "xsl:use-attribute-sets"
is invalid; token "{$additional.title.properties}" invalid; must be an XML QName
```

The fix is ugly and works, but I'm not really happy with this. It repeats a lot of stuff, but I don't know of a better solution to insert the attribute set.
