### PR TITLE
Hyphenate Filenames

### DIFF
--- a/suse2013/fo/hyphenate-url.xsl
+++ b/suse2013/fo/hyphenate-url.xsl
@@ -1,5 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- $Id: hyphenate-url.xsl 43839 2009-08-31 14:50:03Z toms $ -->
+<!--
+  Purpose:
+    Hyphenate URLs and filename-like strings
+
+  Dependand Parameters:
+   * ulink.hyphenate
+     http://docbook.sourceforge.net/release/xsl/current/doc/fo/ulink.hyphenate.html
+
+  Templates:
+   * hyphenate-url: Prepare URL to be hyphenated
+     Parameters:
+     - url: The respective URL
+     - removestartslash: Remove a start slash, if available?
+     - removeendslash:   Remove the trailing slash, if available?
+     - insertendslash:   Insert a slash at the end of the hyphenated URL?
+
+   * hyphenate-url-string: Hyphenate URL
+     Parameters:
+     - url: The URL, removed from schemas like http://, ftp://, etc. and
+            a trailing slash
+
+   Modes:
+    * hyphenate-url
+
+
+  Author(s):  Stefan Knorr <sknorr@suse.de>,
+              Thomas Schraitle <toms@opensuse.org>
+
+  Copyright:  2013-2017 Stefan Knorr, Thomas Schraitle
+
+-->
 <!DOCTYPE xsl:stylesheet >
 <xsl:stylesheet version="1.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -7,12 +37,6 @@
 
 <!-- 
  Template hyphenate-url: Prepare URL to be hyphenated
-
- Parameters:
- * url: The respective URL
- * removestartslash: Remove a start slash, if available?
- * removeendslash:   Remove the trailing slash, if available?
- * insertendslash:   Insert a slash at the end of the hyphenated URL?
 -->
 <xsl:template name="hyphenate-url">
   <xsl:param name="url" select="''"/>
@@ -113,10 +137,6 @@
 
 <!-- 
  Template hyphenate-url-string: Hyphenate URL
- 
- Parameter:
- * url: The URL, removed from schemas like http://, ftp://, etc. and
-        a trailing slash
 -->
 <xsl:template name="hyphenate-url-string">
   <xsl:param name="url" select="''"/>
@@ -183,6 +203,5 @@
    </xsl:with-param>
  </xsl:call-template>
 </xsl:template>
-
 
 </xsl:stylesheet>

--- a/suse2013/fo/inline.xsl
+++ b/suse2013/fo/inline.xsl
@@ -293,7 +293,7 @@
 </xsl:template>
 
 <xsl:template match="classname|exceptionname|interfacename|methodname
-                    |computeroutput|constant|envar|filename|function|literal
+                    |computeroutput|constant|envar|function|literal
                     |code|option|parameter|prompt|systemitem|varname|email|uri
                     |cmdsynopsis/command|package">
   <xsl:param name="purpose" select="'none'"/>
@@ -303,6 +303,25 @@
     <xsl:with-param name="purpose" select="$purpose"/>
     <xsl:with-param name="mode" select="$mode"/>
   </xsl:call-template>
+</xsl:template>
+
+<xsl:template match="filename">
+  <xsl:param name="purpose" select="'none'"/>
+  <xsl:param name="mode" select="'normal'"/>
+
+ <fo:inline xsl:use-attribute-sets="ulink.properties" color="inherit">
+  <xsl:call-template name="inline.monoseq">
+    <xsl:with-param name="purpose" select="$purpose"/>
+    <xsl:with-param name="mode" select="$mode"/>
+    <xsl:with-param name="content">
+      <xsl:call-template name="simple.xlink">
+        <xsl:with-param name="content">
+          <xsl:apply-templates select="." mode="hyphenate-url"/>
+        </xsl:with-param>
+      </xsl:call-template>
+  </xsl:with-param>
+  </xsl:call-template>
+ </fo:inline>
 </xsl:template>
 
 <xsl:template match="sgmltag|tag" name="sgmltag">
@@ -397,8 +416,7 @@
   </xsl:call-template>
 </xsl:template>
 
-<xsl:template match="replaceable|structfield"
-  mode="mono-ancestor">
+<xsl:template match="replaceable|structfield" mode="mono-ancestor">
   <xsl:param name="purpose" select="'none'"/>
 
   <xsl:call-template name="inline.italicmonoseq">
@@ -422,6 +440,7 @@
  </xsl:choose>
 </xsl:template>
 
+<!-- ##################################################################### -->
 <xsl:template match="keycap">
   <xsl:variable name="cap">
     <xsl:choose>

--- a/suse2013/fo/param.xsl
+++ b/suse2013/fo/param.xsl
@@ -394,13 +394,13 @@ USA</xsl:param>
 
 
 <!-- Characters for the hyphenation algorithm:
-          Contains characters hyhenated before or after other text
+     Contains characters "hyhenated" before or after other text
 -->
 <xsl:param name="ulink.hyphenate.before.chars"
    >.,%?&amp;#\~+{_-</xsl:param>
 <xsl:param name="ulink.hyphenate.after.chars"
    >/:@=};</xsl:param>
-
+<xsl:param name="ulink.hyphenate">&#x200B;</xsl:param>
 
 <!-- Show arrows before and after a paragraph that applies only to a certain
      architecture? -->

--- a/tests/dapscompare-tests/db5-inline/xml/test.xml
+++ b/tests/dapscompare-tests/db5-inline/xml/test.xml
@@ -135,6 +135,10 @@
      <filename>/usr/share/xml/docbook/stylesheet/nwalsh/<replaceable>VERSION</replaceable>/fo/inline.xsl</filename>.
     The looooooong winding road to <filename>/etc/bash_completion.d/rpmdevtools.bash-completion</filename>.
    </para>
+   <para>
+    If the operation is performed properly, change the last line in the
+    <filename>/etc/salt/master.d/reactor.conf</filename>:
+   </para>
   </sect1>
  </chapter>
 </book>

--- a/tests/dapscompare-tests/db5-inline/xml/test.xml
+++ b/tests/dapscompare-tests/db5-inline/xml/test.xml
@@ -94,5 +94,47 @@
    single-origin coffee plaid, street art readymade selfies craft beer
    chartreuse etsy man bun blue bottle subway tile hella.
   </para>
+  <sect1>
+   <title>Hyphenated Filenames</title>
+   <para>
+    The brown, grumpy, heavy, disgruntled tapir falls onto the long and
+    nice file
+     <filename>/usr/share/xml/docbook/stylesheet/nwalsh/current/fo/inline.xsl</filename>.
+   </para>
+   <para>
+    The brown, grumpy, heavy, disgruntled tapir falls onto the long and
+    niiiiice file
+     <filename>/etc/fop.xconf</filename>.
+   </para>
+   <para>
+    The grumpy, heavy, disgruntled elephant dances around the file
+     <filename>/usr/share/xml/docbook/stylesheet/nwalsh/current/fo/inline.xsl</filename>.
+   </para>
+   <para>
+    The grumpy, heavy, funnny disgruntled falls onto the long and
+    nice file
+     <filename>/usr/share/xml/docbook/stylesheet/nwalsh/current/fo/inline.xsl</filename>.
+   </para>
+   <para>
+    The disgruntled tapir falls onto the long and
+    nice file
+     <filename>/usr/share/xml/docbook/stylesheet/nwalsh/current/fo/inline.xsl</filename>.
+   </para>
+   <para>
+    The disgruntled tapir falls onto the long and
+    nice file
+     <filename>/usr/share/xml/docbook/stylesheet/nwalsh/<replaceable>VERSION</replaceable>/fo/inline.xsl</filename>.
+   </para>
+   <para>
+    The disgruntled tapir looong file
+     <filename>/usr/share/xml/docbook/stylesheet/nwalsh/<replaceable>VERSION</replaceable>/fo/inline.xsl</filename>.
+   </para>
+   <para>
+    The disgruntled tapir falls onto the long and
+    nice file
+     <filename>/usr/share/xml/docbook/stylesheet/nwalsh/<replaceable>VERSION</replaceable>/fo/inline.xsl</filename>.
+    The looooooong winding road to <filename>/etc/bash_completion.d/rpmdevtools.bash-completion</filename>.
+   </para>
+  </sect1>
  </chapter>
 </book>


### PR DESCRIPTION
Related to issue #339.

This PR contains the following changes:

* Create filename template
* Enable ZERO WIDTH SPACE (U+200B) in parameter `ulink.hyphenate`
* Minor comment and linebreak fixes
* Add hyphenation testcases

The result will look like this:

![hyph-filename](https://user-images.githubusercontent.com/1312925/30905839-567123da-a376-11e7-93e4-0fb334ab0c5e.png)

I'm not sure if we should enable it. Please **DO NOT** merge it for the time being, as we should investigate it a bit further. It's just a "proof of concept" which we can play around, but I wouldn't want to see it in production code yet.

At the moment, we should keep in mind the following:

* Our text is justified. This could lead to bigger gaps in the text if the filename cannot be broken at some characters.
* Links should be hyphenated as well; this isn't covered in this PR (yet).
* ATM, it seems the filenames are only broken up at the "/" (slash) character. Not sure why other characters are not taken into account.
* We should test it with the latest FOP 2.2.
