### PR TITLE
Explicitly mention documentation in 'Report Bug' links

### DIFF
--- a/suse2013/static/js/script.js
+++ b/suse2013/static/js/script.js
@@ -163,7 +163,7 @@ function tracker() {
 
       $(this).before("<a class=\"report-bug\" target=\"_blank\" href=\""
         + url
-        + "\" title=\"Report a bug against this section\">Report Bug</a> ");
+        + "\" title=\"Report a documentation bug against this section\">Report Documentation Bug</a> ");
       return true;
     });
   }


### PR DESCRIPTION
As suggested by @taroth21 last week, we should explicitly mention documentation in the 'Report Bug' links.