### PR TITLE
Fix #422: Add "last modified" line on cover page

### DIFF
--- a/suse2013/common/l10n/en.xml
+++ b/suse2013/common/l10n/en.xml
@@ -38,6 +38,7 @@
    <l:gentext key="susecontact" text="Contact Us"/>
    <l:gentext key="version.info" text="Applies to "/>
    <l:gentext key="totopofpage" text="Top"/>
+   <l:gentext key="last.modified" text="Last modified"/>
 
    <l:gentext key="version" text="Version"/>
    <l:gentext key="Version" text="Version"/>

--- a/suse2013/fo/param.xsl
+++ b/suse2013/fo/param.xsl
@@ -415,4 +415,11 @@ USA</xsl:param>
 <!-- Trim away empty lines from the beginning and end of screens -->
 <xsl:param name="trim.verbatim" select="1"/>
 
+
+  <!-- The date at when the document was modified
+    Leave empty if you do not want to add a line with:
+    "modified at $doc.modified"
+  -->
+  <xsl:param name="last.modified"/>
+
 </xsl:stylesheet>

--- a/suse2013/xhtml/param.xsl
+++ b/suse2013/xhtml/param.xsl
@@ -411,4 +411,10 @@ task before
        og:description/meta description tags.-->
   <xsl:param name="teaser.length" select="300"/>
 
+  <!-- The date at when the document was modified
+    Leave empty if you do not want to add a line with:
+    "modified at $doc.modified"
+  -->
+  <xsl:param name="last.modified"/>
+
 </xsl:stylesheet>

--- a/suse2013/xhtml/titlepage.templates.xsl
+++ b/suse2013/xhtml/titlepage.templates.xsl
@@ -447,6 +447,18 @@
     <div class="date">
       <xsl:call-template name="date.and.revision.inner"/>
     </div>
+
+    <xsl:if test="$last.modified != ''">
+      <div class="date lastmodified">
+        <span class="imprint-label">
+          <xsl:call-template name="gentext">
+            <xsl:with-param name="key">last.modified</xsl:with-param>
+          </xsl:call-template>
+          <xsl:text>: </xsl:text>
+        </span>
+        <xsl:value-of select="normalize-space($last.modified)"/>
+      </div>
+    </xsl:if>
 </xsl:template>
 
 <xsl:template name="imprint.label">


### PR DESCRIPTION
This is a proof-of-concept and a draft ATM. It contains the following changes:

* Introduce parameter `last.modified` for FO and XHTML, by default empty
* Introduce a `last.modified` key in language file (currently only en ATM)
* When the cover page is created, only add "Last modified"  line when $last.modified != ''.

Currently, the parameter $last.modified is used "as-is"; it is included in the respective line no matter if it's a date or not.

However, when a date is passed, it is currently inconsistent with the publication date. This looks like this:

**Publication Date:** October 29, 2020
**Last modified:** 2020-10-01

That first date is created from this line:

    <date><?dbtimestamp format="B d, Y"?></date>

In other words, to make both dates consistent, the last modified date needs to be transformed into the format of the PI inside `<date>`.