### PR TITLE
Style <result> element (#286)

### DIFF
--- a/suse2013/fo/lists.xsl
+++ b/suse2013/fo/lists.xsl
@@ -176,7 +176,8 @@
 
   <!-- Preserve order of PIs and comments -->
   <xsl:variable name="preamble"
-        select="*[not(self::step
+    select="*[not(self::step
+                  or self::result
                   or self::title
                   or self::titleabbrev)]
                 |comment()[not(preceding-sibling::step)]
@@ -224,6 +225,7 @@
         xsl:use-attribute-sets="list.block.spacing list.block.properties">
         <xsl:apply-templates select="$steps"/>
       </fo:list-block>
+      <xsl:apply-templates select="result"/>
     </fo:block>
 
     <xsl:if test="./title and $placement != 'before'">
@@ -286,6 +288,25 @@
       </fo:block>
     </fo:list-item-body>
   </fo:list-item>
+</xsl:template>
+
+<xsl:template match="result[para]">
+    <fo:block xsl:use-attribute-sets="list.block.spacing">
+      <xsl:attribute name="margin-{$start-border}"><xsl:value-of
+          select="&mediumline; div 2"/>mm</xsl:attribute>
+<!--      <fo:block font-weight="bold">Result</fo:block>-->
+      <!--<fo:instream-foreign-object content-height="0.4em"
+        alignment-baseline="alphabetic" alignment-adjust="0.175em">
+        <s:svg xmlns:s="http://www.w3.org/2000/svg" width="100" height="100">
+          <s:path d="m0 0 L100 50 L0 100 Z" color="gray"/>
+        </s:svg>
+      </fo:instream-foreign-object>
+      -->
+      <!--<fo:inline>❯ </fo:inline>
+      <xsl:apply-templates select="para[1]/node()"/>
+      <xsl:apply-templates select="*[not(self::para[1])]"/>-->
+      <xsl:apply-templates/>
+    </fo:block>
 </xsl:template>
 
 <!-- Special handling for arch attributes + Don't break after colons. -->

--- a/suse2013/static/css/style.css
+++ b/suse2013/static/css/style.css
@@ -2425,6 +2425,14 @@ li > p {
     margin: 0 10px 5px;
 }
 
+.result {
+  margin-left: -20px;
+}
+
+.result-title {
+  font-weight: bold;
+}
+
 div.itemizedlist {
     margin: 0 0 24px;
 }

--- a/suse2013/xhtml/lists.xsl
+++ b/suse2013/xhtml/lists.xsl
@@ -35,6 +35,7 @@
     <!-- Preserve order of PIs and comments -->
     <xsl:variable name="preamble"
         select="*[not(self::step
+                  or self::result
                   or self::title
                   or self::titleabbrev)]
                   |comment()[not(preceding-sibling::step)]
@@ -65,6 +66,7 @@
               select="step
                      |comment()[preceding-sibling::step]
                      |processing-instruction()[preceding-sibling::step]"/>
+            <xsl:apply-templates select="result"/>
           </ul>
         </xsl:when>
         <xsl:otherwise>
@@ -77,6 +79,7 @@
               select="step
                      |comment()[preceding-sibling::step]
                      |processing-instruction()[preceding-sibling::step]"/>
+            <xsl:apply-templates select="result"/>
           </ol>
         </xsl:otherwise>
       </xsl:choose>
@@ -132,6 +135,15 @@
        <xsl:apply-templates/>
      </xsl:with-param>
    </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template match="result">
+    <div class="result">
+      <xsl:call-template name="common.html.attributes"/>
+      <xsl:call-template name="id.attribute"/>
+      <div class="result-title"/>
+      <xsl:apply-templates/>
+    </div>
   </xsl:template>
 
 <xsl:template match="listitem/simpara" priority="10">

--- a/suse2022-ns/fo/lists.xsl
+++ b/suse2022-ns/fo/lists.xsl
@@ -178,6 +178,7 @@
   <!-- Preserve order of PIs and comments -->
   <xsl:variable name="preamble"
         select="*[not(self::d:step
+                  or self::d:result
                   or self::d:title
                   or self::d:titleabbrev)]
                 |comment()[not(preceding-sibling::d:step)]
@@ -225,6 +226,7 @@
         xsl:use-attribute-sets="list.block.spacing list.block.properties">
         <xsl:apply-templates select="$steps"/>
       </fo:list-block>
+      <xsl:apply-templates select="d:result"/>
     </fo:block>
 
     <xsl:if test="./d:title and $placement != 'before'">
@@ -287,6 +289,26 @@
       </fo:block>
     </fo:list-item-body>
   </fo:list-item>
+</xsl:template>
+
+<xsl:template match="d:result"> <!-- d:result[d:para] -->
+    <fo:block xsl:use-attribute-sets="list.block.spacing">
+      <xsl:attribute name="margin-{$start-border}"><xsl:value-of
+        select="&mediumline; div 2"/>mm</xsl:attribute>
+      <!--      <fo:block font-weight="bold">Result</fo:block>-->
+      <!--<fo:instream-foreign-object content-height="0.4em"
+        alignment-baseline="alphabetic" alignment-adjust="0.175em">
+        <s:svg xmlns:s="http://www.w3.org/2000/svg" width="100" height="100">
+          <s:path d="m0 0 L100 50 L0 100 Z" color="gray"/>
+        </s:svg>
+      </fo:instream-foreign-object>-->
+      <!--
+      <fo:inline>❯ </fo:inline>
+      <xsl:apply-templates select="d:para[1]/node()"/>
+      <xsl:apply-templates select="*[not(self::d:para[1])]"/>
+      -->
+      <xsl:apply-templates/>
+    </fo:block>
 </xsl:template>
 
 <!-- Special handling for arch attributes + Don't break after colons. -->

--- a/suse2022-ns/xhtml/lists.xsl
+++ b/suse2022-ns/xhtml/lists.xsl
@@ -36,6 +36,7 @@
     <!-- Preserve order of PIs and comments -->
     <xsl:variable name="preamble"
         select="*[not(self::d:step
+                  or self::d:result
                   or self::d:title
                   or self::d:titleabbrev)]
                   |comment()[not(preceding-sibling::d:step)]
@@ -66,6 +67,7 @@
               select="d:step
                      |comment()[preceding-sibling::d:step]
                      |processing-instruction()[preceding-sibling::d:step]"/>
+            <xsl:apply-templates select="d:result"/>
           </ul>
         </xsl:when>
         <xsl:otherwise>
@@ -78,6 +80,7 @@
               select="d:step
                      |comment()[preceding-sibling::d:step]
                      |processing-instruction()[preceding-sibling::d:step]"/>
+            <xsl:apply-templates select="d:result"/>
           </ol>
         </xsl:otherwise>
       </xsl:choose>
@@ -157,4 +160,14 @@
   </xsl:call-template>
 </xsl:template>
 
+
+  <xsl:template match="d:result">
+    <div class="result">
+      <xsl:call-template name="common.html.attributes"/>
+      <xsl:call-template name="id.attribute"/>
+      <div class="result-title"/>
+      <!--<p class="result-title">Result</p>-->
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
 </xsl:stylesheet>

--- a/tests/dapscompare-tests/db5-result/DC-art
+++ b/tests/dapscompare-tests/db5-result/DC-art
@@ -1,0 +1,5 @@
+MAIN="test.xml"
+ROOTID="cha.procedure"
+
+STYLEROOT="../../../build/stylesheet/suse2013-ns"
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/tests/dapscompare-tests/db5-result/xml/test.xml
+++ b/tests/dapscompare-tests/db5-result/xml/test.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook50-profile.xsl"
+                 type="text/xml"
+                 title="Profiling step"?>
+<!DOCTYPE book
+[
+]>
+
+<book xml:lang="en" xml:id="book.foo"
+  xmlns="http://docbook.org/ns/docbook"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Foo Bar in the Fooish Bar DB5</title>
+ <info>
+  <productname>Long Long Name Name</productname>
+  <productname role="abbrev">Shortname</productname>
+  <productnumber>93/4</productnumber>
+  <authorgroup>
+   <author>
+    <personname>
+     <firstname>Linda</firstname>
+     <surname>McLane</surname>
+    </personname>
+   </author>
+   <author>
+    <personname>
+     <firstname>Lance</firstname>
+     <surname>McLorne</surname>
+    </personname>
+   </author>
+   <author>
+    <personname>
+     <firstname>Ludvig</firstname>
+     <surname>McLence</surname>
+    </personname>
+   </author>
+  </authorgroup>
+  <date>2016-10-31</date>
+  <abstract>
+   <para>
+    Gluten-free kitsch scenester mumblecore quinoa, la croix post-ironic
+    meditation kinfolk schlitz. Letterpress church-key subway tile synth
+    flannel. Irony kombucha crucifix you probably haven't heard of them kale
+    chips pitchfork. Poke gluten-free activated charcoal tilde plaid, fam
+    butcher franzen tumblr brooklyn. Normcore church-key vape chicharrones
+    godard kombucha, forage heirloom.
+   </para>
+  </abstract>
+ </info>
+
+ <chapter xml:id="cha.procedure">
+  <title>Procedures with <tag>result</tag> tag</title>
+  <para>
+   Truffaut prism pinterest,  biodiesel ethical schlitz etsy blog. Venmo
+   salvia shabby chic ramps tofu microdosing.
+  </para>
+  <procedure>
+  <title>Use brunch to make sappy slow-carb</title>
+  <step>
+   <para>
+    Aesthetic put a bird on it waistcoat brunch tumeric.
+   </para>
+   <result>
+    <para>The result of brunch tumeric.</para>
+    <para>Another para of a result.</para>
+   </result>
+  </step>
+  <step>
+   <para>
+    Snackwave chambray succulents sartorial.
+   </para>
+   <result>
+    <para>The result of succulents sartorial.</para>
+   </result>
+  </step>
+  <step>
+   <para>
+     Stumptown banjo disrupt intelligentsia 8-bit slow-carb.
+   </para>
+  </step>
+  <result>
+   <para>You are a sappy customer, congrats!
+   </para>
+  </result>
+ </procedure>
+ </chapter>
+</book>


### PR DESCRIPTION
This PR contains a proof-of-concept and fixes #286:

* Implement `<result>` as last possible element of `<procedure>`.
* Introduce a `<div class="result"` container for the `result` element.
* Use hard-coded "Result" term for the time being.

TODOs:

* "Result" term needs to be localized.
* Applied to FO as well.
* Implement `<result>` as last element inside `<step>`.
---

![Screenshot_20210225_133423](https://user-images.githubusercontent.com/1312925/109154149-2f622080-776e-11eb-85fe-ed6292dfeeb2.png)

