### PR TITLE
Fix #437: rename lang -> xml:lang, id -> xml:id

### DIFF
--- a/suse2021-ns/common/screen-length.xsl
+++ b/suse2021-ns/common/screen-length.xsl
@@ -66,9 +66,9 @@
       <xsl:call-template name="log.message">
         <xsl:with-param name="level">Warn</xsl:with-param>
         <xsl:with-param name="source">
-          <xsl:if test="(./ancestor-or-self::*/@id|./ancestor-or-self::*/@xml:id)">
+          <xsl:if test="ancestor-or-self::*/@xml:id">
             <xsl:text>(in </xsl:text>
-            <xsl:value-of select="(./ancestor-or-self::*/@id|./ancestor-or-self::*/@xml:id)[last()]"/>
+            <xsl:value-of select="(ancestor-or-self::*/@xml:id)[last()]"/>
             <xsl:text>)</xsl:text>
           </xsl:if>
         </xsl:with-param>

--- a/suse2021-ns/common/xref.xsl
+++ b/suse2021-ns/common/xref.xsl
@@ -22,7 +22,7 @@
   <xsl:param name="linkend"/>
   <xsl:param name="first" select="0"/>
   <xsl:message>WARNING: Element <xsl:value-of select="local-name(.)"/> cannot be used for intra xref linking.
-  - affected ID: <xsl:value-of select="(./@id|./@xml:id)[last()]"/>
+  - affected ID: <xsl:value-of select="@xml:id"/>
   - linkend: <xsl:value-of select="$linkend"/></xsl:message>
 </xsl:template>
 

--- a/suse2021-ns/xhtml/chunk-common.xsl
+++ b/suse2021-ns/xhtml/chunk-common.xsl
@@ -108,8 +108,8 @@
           <xsl:when test="$rootelementname != 'article'">
             <xsl:for-each select="ancestor-or-self::*">
               <xsl:choose>
-                <xsl:when test="$rootid != '' and descendant::*[@id = string($rootid)]"/>
-                <xsl:when test="not(ancestor::*) or @id = string($rootid)">
+                <xsl:when test="$rootid != '' and descendant::*[@xml:id = string($rootid)]"/>
+                <xsl:when test="not(ancestor::*) or @xml:id = string($rootid)">
                   <xsl:apply-templates select="." mode="breadcrumbs">
                     <xsl:with-param name="class">book-link</xsl:with-param>
                   </xsl:apply-templates>
@@ -567,7 +567,7 @@
     <xsl:param name="content"/>
 
     <xsl:variable name="lang">
-      <xsl:apply-templates select="(ancestor-or-self::*/@lang)[last()]" mode="html.lang.attribute"/>
+      <xsl:apply-templates select="(ancestor-or-self::*/@xml:lang)[last()]" mode="html.lang.attribute"/>
     </xsl:variable>
 
     <xsl:call-template name="user.preroot"/>

--- a/suse2021-ns/xhtml/docbook.xsl
+++ b/suse2021-ns/xhtml/docbook.xsl
@@ -691,7 +691,7 @@
   </xsl:param>
   <xsl:variable name="doc" select="self::*"/>
   <xsl:variable name="lang">
-    <xsl:apply-templates select="(ancestor-or-self::*/@lang)[last()]" mode="html.lang.attribute"/>
+    <xsl:apply-templates select="(ancestor-or-self::*/@xml:lang)[last()]" mode="html.lang.attribute"/>
   </xsl:variable>
   <xsl:call-template name="user.preroot"/>
   <xsl:call-template name="root.messages"/>

--- a/suse2021-ns/xhtml/html.xsl
+++ b/suse2021-ns/xhtml/html.xsl
@@ -27,7 +27,7 @@
             <xsl:when test="$generate.id.attributes = 0 and $force != 1">
                 <!-- No id attributes when this param is zero -->
             </xsl:when>
-            <xsl:when test="($force = 1 or $conditional = 0 or $node/@id or $node/@xml:id)
+            <xsl:when test="($force = 1 or $conditional = 0 or $node/@xml:id)
                 and local-name($node) != 'figure'">
                 <xsl:attribute name="id">
                     <xsl:call-template name="object.id">

--- a/suse2021-ns/xhtml/param.xsl
+++ b/suse2021-ns/xhtml/param.xsl
@@ -395,7 +395,7 @@ task before
        architecture? -->
   <xsl:param name="para.use.arch" select="1"/>
 
-  <!-- Output a warning, if chapter/@lang is different from book/@lang ?
+  <!-- Output a warning, if chapter/@xml:lang is different from book/@xml:lang ?
        0=no, 1=yes
   -->
 <xsl:param name="warn.xrefs.into.diff.lang" select="1"/>

--- a/suse2021-ns/xhtml/sections.xsl
+++ b/suse2021-ns/xhtml/sections.xsl
@@ -294,7 +294,7 @@ elements, to fix their display. -->
         <li>
           <span class="ds-label">ID: </span>
           <xsl:choose>
-            <xsl:when test="$node/parent::*[(@id|@xml:id)[1]] != ''">
+            <xsl:when test="$node/parent::*[@xml:id] != ''">
               <xsl:call-template name="object.id">
                 <xsl:with-param name="object" select="$node/parent::*"/>
               </xsl:call-template>


### PR DESCRIPTION
This PR adds the `xml:` prefix to the attributes `@lang` and `@id`. In some cases, it simplifies the XPath expression.

TODO: check if everything is still okay.
