### PR TITLE
Implement color for phrase/para

### DIFF
--- a/suse2022-ns/common/utility.xsl
+++ b/suse2022-ns/common/utility.xsl
@@ -128,33 +128,30 @@
       <xsl:when test="starts-with($value, '#') and string-length($value) &lt;= 7">
         <xsl:value-of select="$value"/>
       </xsl:when>
-      <xsl:when test="$value = 'aqua' or
-                      $value = 'black' or
-                      $value = 'blue' or
-                      $value = 'darkgray' or $value = 'darkgrey' or
-                      $value = 'fuchsia' or
-                      $value = 'gray' or $value = 'grey' or
-                      $value = 'green' or
-                      $value = 'lime' or
-                      $value = 'maroon' or
-                      $value = 'navy' or
-                      $value = 'olive' or
-                      $value = 'orange' or
-                      $value = 'purple' or
-                      $value = 'red' or
-                      $value = 'teal' or
-                      $value = 'white' or
-                      $value = 'yellow'">
-        <xsl:value-of select="$value"/>
-      </xsl:when>
-      <!-- SUSE colors -->
+      <!-- SUSE colors primary colors don't have 60% and 30% -->
       <xsl:when test="$value = 'suse-pine-green'">#0C322C</xsl:when>
       <xsl:when test="$value = 'suse-jungle-green'">#30BA78</xsl:when>
+      <xsl:when test="$value = 'suse-white'">#FFFFFF</xsl:when>
+      <!--  -->
       <xsl:when test="$value = 'suse-midnight-blue'">#192072</xsl:when>
+      <xsl:when test="$value = 'suse-midnight-blue-60'">#757AA7</xsl:when>
+      <xsl:when test="$value = 'suse-midnight-blue-30'">#BBBDD4</xsl:when>
+      <!--  -->
       <xsl:when test="$value = 'suse-waterhole-blue'">#2453FF</xsl:when>
+      <xsl:when test="$value = 'suse-waterhole-blue-60'">#809AF7</xsl:when>
+      <xsl:when test="$value = 'suse-waterhole-blue-30'">#BFCBFB</xsl:when>
+      <!--  -->
       <xsl:when test="$value = 'suse-mint'">#90EBCD</xsl:when>
+      <xsl:when test="$value = 'suse-mint-60'">#C7F1E3</xsl:when>
+      <xsl:when test="$value = 'suse-mint-30'">#E3F8F1</xsl:when>
+      <!--  -->
       <xsl:when test="$value = 'suse-persimmon'">#FE7C3F</xsl:when>
+      <xsl:when test="$value = 'suse-persimmon-60'">#F3B292</xsl:when>
+      <xsl:when test="$value = 'suse-persimmon-30'">#F9DAC8</xsl:when>
+      <!--  -->
       <xsl:when test="$value = 'suse-fog'">#EFEFEF</xsl:when>
+      <xsl:when test="$value = 'suse-fog-200'">#DEDFE0</xsl:when>
+      <xsl:when test="$value = 'suse-fog-300'">#C0C2C4</xsl:when>
       <xsl:otherwise>
         <xsl:call-template name="log.message">
           <xsl:with-param name="level">info</xsl:with-param>

--- a/suse2022-ns/common/utility.xsl
+++ b/suse2022-ns/common/utility.xsl
@@ -119,4 +119,57 @@
     </xsl:choose>
   </xsl:template>
 
+
+  <!--  -->
+  <xsl:template name="get-suse-color">
+    <xsl:param name="value"/>
+    <xsl:choose>
+      <!-- When it's starting with a hash-mark, assume we have a color -->
+      <xsl:when test="starts-with($value, '#') and string-length($value) &lt;= 7">
+        <xsl:value-of select="$value"/>
+      </xsl:when>
+      <xsl:when test="$value = 'aqua' or
+                      $value = 'black' or
+                      $value = 'blue' or
+                      $value = 'darkgray' or $value = 'darkgrey' or
+                      $value = 'fuchsia' or
+                      $value = 'gray' or $value = 'grey' or
+                      $value = 'green' or
+                      $value = 'lime' or
+                      $value = 'maroon' or
+                      $value = 'navy' or
+                      $value = 'olive' or
+                      $value = 'orange' or
+                      $value = 'purple' or
+                      $value = 'red' or
+                      $value = 'teal' or
+                      $value = 'white' or
+                      $value = 'yellow'">
+        <xsl:value-of select="$value"/>
+      </xsl:when>
+      <!-- SUSE colors -->
+      <xsl:when test="$value = 'suse-pine-green'">#0C322C</xsl:when>
+      <xsl:when test="$value = 'suse-jungle-green'">#30BA78</xsl:when>
+      <xsl:when test="$value = 'suse-midnight-blue'">#192072</xsl:when>
+      <xsl:when test="$value = 'suse-waterhole-blue'">#2453FF</xsl:when>
+      <xsl:when test="$value = 'suse-mint'">#90EBCD</xsl:when>
+      <xsl:when test="$value = 'suse-persimmon'">#FE7C3F</xsl:when>
+      <xsl:when test="$value = 'suse-fog'">#EFEFEF</xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="log.message">
+          <xsl:with-param name="level">info</xsl:with-param>
+          <xsl:with-param name="context-desc">layout</xsl:with-param>
+          <xsl:with-param name="message">
+            <xsl:text>The value '</xsl:text>
+            <xsl:value-of select="$value"/>
+            <xsl:text>' seems to be an invalid color. </xsl:text>
+            <xsl:text>Use either #RRGGBB or one of the names: suse-pine-green, </xsl:text>
+            <xsl:text>suse-jungle-green, suse-midnight-blue, suse-waterhole-blue, </xsl:text>
+            <xsl:text>suse-mint, suse-persimmon, or suse-fog.</xsl:text>
+          </xsl:with-param>
+        </xsl:call-template>
+        <xsl:text>inherit</xsl:text><!-- the default -->
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/suse2022-ns/fo/block.xsl
+++ b/suse2022-ns/fo/block.xsl
@@ -19,10 +19,11 @@
   %metrics;
   <!ENTITY punctuation "!,,.::;?;־׀׃׆׳״؞؟‒–—―․‥…‼‽⁇⁈⁉⁏⁓⁕⁖⁘⁙⁚❓❔❕❗❢❣⸪⸫⸬⸺⸻。〜〰꓾꓿︐︑︒︓︔︕︖︙︱︲﹐﹑﹒﹔﹕﹖﹗﹘！，－．：；？｡､">
 ]>
-<xsl:stylesheet exclude-result-prefixes="d"
-                 version="1.0"
+<xsl:stylesheet version="1.0"
+  exclude-result-prefixes="d la"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:la="urn:x-suse:xslt:layout"
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
   xmlns:svg="http://www.w3.org/2000/svg">
 
@@ -206,6 +207,15 @@
   <xsl:variable name="content">
     <xsl:value-of select="normalize-space(.)"/>
   </xsl:variable>
+  <xsl:variable name="text-color">
+    <xsl:if test="processing-instruction('dbsuse')">
+      <xsl:call-template name="pi-attribute">
+        <xsl:with-param name="pis"
+          select="processing-instruction('dbsuse')" />
+        <xsl:with-param name="attribute">color</xsl:with-param>
+      </xsl:call-template>
+    </xsl:if>
+  </xsl:variable>
   <!-- We need only one final character, but there may be
        something in the way, like a space that wasn't removed or so. -->
   <xsl:variable name="final-characters"
@@ -215,6 +225,11 @@
     <xsl:if test="$keep.together != ''">
       <xsl:attribute name="keep-together.within-column"><xsl:value-of
                       select="$keep.together"/></xsl:attribute>
+    </xsl:if>
+    <xsl:if test="$text-color">
+      <xsl:attribute name="color">
+        <xsl:value-of select="$text-color"/>
+      </xsl:attribute>
     </xsl:if>
     <xsl:call-template name="no-break-after-colon"/>
 

--- a/suse2022-ns/fo/block.xsl
+++ b/suse2022-ns/fo/block.xsl
@@ -208,13 +208,26 @@
     <xsl:value-of select="normalize-space(.)"/>
   </xsl:variable>
   <xsl:variable name="text-color">
-    <xsl:if test="processing-instruction('dbsuse')">
-      <xsl:call-template name="pi-attribute">
-        <xsl:with-param name="pis"
-          select="processing-instruction('dbsuse')" />
-        <xsl:with-param name="attribute">color</xsl:with-param>
-      </xsl:call-template>
-    </xsl:if>
+    <xsl:choose>
+      <xsl:when test="processing-instruction('dbsuse')">
+        <xsl:call-template name="get-suse-color">
+          <xsl:with-param name="value">
+            <xsl:call-template name="pi-attribute">
+              <xsl:with-param name="pis"
+                select="processing-instruction('dbsuse')" />
+              <xsl:with-param name="attribute">color</xsl:with-param>
+            </xsl:call-template>
+          </xsl:with-param>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="starts-with(@role, 'color:')">
+	<!-- <xsl:message>d:phrase color="<xsl:value-of select="substring-after(., 'color:')"/>"</xsl:message>-->
+        <xsl:call-template name="get-suse-color">
+          <xsl:with-param name="value" select="substring-after(@role, 'color:')"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>inherit</xsl:otherwise>
+    </xsl:choose>
   </xsl:variable>
   <!-- We need only one final character, but there may be
        something in the way, like a space that wasn't removed or so. -->

--- a/suse2022-ns/fo/inline.xsl
+++ b/suse2022-ns/fo/inline.xsl
@@ -41,10 +41,11 @@
                                 parent::d:simplesect|parent::d:taskprerequisites|parent::d:taskrelated|
                                 parent::d:tasksummary|parent::d:warning|parent::d:topic">
 ]>
-<xsl:stylesheet exclude-result-prefixes="d"
-                 version="1.0"
+<xsl:stylesheet version="1.0"
+  exclude-result-prefixes="d la"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:la="urn:x-suse:xslt:layout"
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
   xmlns:svg="http://www.w3.org/2000/svg">
 
@@ -516,6 +517,29 @@
 
 <xsl:template match="d:package">
   <xsl:call-template name="inline.monoseq"/>
+</xsl:template>
+
+<xsl:template match="d:phrase">
+    <xsl:variable name="text-color">
+      <xsl:choose>
+        <xsl:when test="processing-instruction('dbsuse')">
+          <xsl:call-template name="get-suse-color">
+            <xsl:with-param name="value">
+              <xsl:call-template name="pi-attribute">
+                <xsl:with-param name="pis"
+                  select="processing-instruction('dbsuse')" />
+                <xsl:with-param name="attribute">color</xsl:with-param>
+              </xsl:call-template>
+            </xsl:with-param>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>inherit</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
+  <fo:inline color="{$text-color}">
+    <xsl:apply-imports/>
+  </fo:inline>
 </xsl:template>
 
 <xsl:template match="d:prompt">

--- a/suse2022-ns/fo/inline.xsl
+++ b/suse2022-ns/fo/inline.xsl
@@ -520,22 +520,28 @@
 </xsl:template>
 
 <xsl:template match="d:phrase">
-    <xsl:variable name="text-color">
-      <xsl:choose>
-        <xsl:when test="processing-instruction('dbsuse')">
-          <xsl:call-template name="get-suse-color">
-            <xsl:with-param name="value">
-              <xsl:call-template name="pi-attribute">
-                <xsl:with-param name="pis"
-                  select="processing-instruction('dbsuse')" />
-                <xsl:with-param name="attribute">color</xsl:with-param>
-              </xsl:call-template>
-            </xsl:with-param>
-          </xsl:call-template>
-        </xsl:when>
-        <xsl:otherwise>inherit</xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
+  <xsl:variable name="text-color">
+    <xsl:choose>
+      <xsl:when test="processing-instruction('dbsuse')">
+        <xsl:call-template name="get-suse-color">
+          <xsl:with-param name="value">
+            <xsl:call-template name="pi-attribute">
+              <xsl:with-param name="pis"
+                select="processing-instruction('dbsuse')" />
+              <xsl:with-param name="attribute">color</xsl:with-param>
+            </xsl:call-template>
+          </xsl:with-param>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="starts-with(@role, 'color:')">
+        <xsl:message>d:phrase color="<xsl:value-of select="substring-after(., 'color:')"/>"</xsl:message>
+        <xsl:call-template name="get-suse-color">
+          <xsl:with-param name="value" select="substring-after(@role, 'color:')"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>inherit</xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
 
   <fo:inline color="{$text-color}">
     <xsl:apply-imports/>

--- a/suse2022-ns/xhtml/block.xsl
+++ b/suse2022-ns/xhtml/block.xsl
@@ -69,7 +69,13 @@
             </xsl:with-param>
           </xsl:call-template>
         </xsl:when>
-        <xsl:otherwise/>
+        <xsl:when test="starts-with(@role, 'color:')">
+          <!-- <xsl:message>d:phrase color="<xsl:value-of select="substring-after(., 'color:')"/>"</xsl:message>-->
+          <xsl:call-template name="get-suse-color">
+            <xsl:with-param name="value" select="substring-after(@role, 'color:')"/>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise />
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="p">

--- a/suse2022-ns/xhtml/block.xsl
+++ b/suse2022-ns/xhtml/block.xsl
@@ -13,10 +13,11 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:d="http://docbook.org/ns/docbook"
     xmlns:exsl="http://exslt.org/common"
+    xmlns:la="urn:x-suse:xslt:layout"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:t="http://nwalsh.com/docbook/xsl/template/1.0"
     xmlns:l="http://docbook.sourceforge.net/xmlns/l10n/1.0"
-    exclude-result-prefixes="exsl l t d">
+    exclude-result-prefixes="exsl l t d la">
 
   <xsl:template match="d:para[@arch]">
     <xsl:variable name="arch">
@@ -50,13 +51,35 @@
 <!-- Same as upstream version, but can also handle paragraphs with an
      architecture assigned to them. -->
   <xsl:template name="paragraph">
+    <xsl:param name="node" select="."/>
     <xsl:param name="class" select="''"/>
     <xsl:param name="content"/>
     <xsl:param name="arch"/>
 
+    <xsl:variable name="text-color">
+      <xsl:choose>
+        <xsl:when test="processing-instruction('dbsuse')">
+          <xsl:call-template name="get-suse-color">
+            <xsl:with-param name="value">
+              <xsl:call-template name="pi-attribute">
+                <xsl:with-param name="pis"
+                  select="processing-instruction('dbsuse')" />
+                <xsl:with-param name="attribute">color</xsl:with-param>
+              </xsl:call-template>
+            </xsl:with-param>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise/>
+      </xsl:choose>
+    </xsl:variable>
     <xsl:variable name="p">
       <p>
         <xsl:call-template name="id.attribute"/>
+        <xsl:if test="$text-color != ''">
+          <xsl:attribute name="style">
+            <xsl:value-of select="concat('color:', $text-color, ';')"/>
+          </xsl:attribute>
+        </xsl:if>
         <xsl:choose>
           <xsl:when test="$class != ''">
             <xsl:call-template name="common.html.attributes">
@@ -83,6 +106,7 @@
         </xsl:if>
       </p>
     </xsl:variable>
+    
 
     <xsl:choose>
       <xsl:when test="$html.cleanup != 0">

--- a/suse2022-ns/xhtml/inline.xsl
+++ b/suse2022-ns/xhtml/inline.xsl
@@ -138,6 +138,12 @@
             </xsl:with-param>
           </xsl:call-template>
         </xsl:when>
+        <xsl:when test="starts-with(@role, 'color:')">
+          <xsl:message>d:phrase color=<xsl:value-of select="substring-after(., 'color:')"/></xsl:message>
+          <xsl:call-template name="get-suse-color">
+            <xsl:with-param name="value" select="substring-after(@role, 'color:')"/>
+          </xsl:call-template>
+        </xsl:when>
         <xsl:otherwise/>
       </xsl:choose>
     </xsl:variable>

--- a/suse2022-ns/xhtml/inline.xsl
+++ b/suse2022-ns/xhtml/inline.xsl
@@ -11,9 +11,10 @@
 <xsl:stylesheet version="1.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:la="urn:x-suse:xslt:layout"
   xmlns:exsl="http://exslt.org/common"
   xmlns="http://www.w3.org/1999/xhtml"
-  exclude-result-prefixes="exsl d">
+  exclude-result-prefixes="exsl d la">
 
 
   <xsl:template name="inline.sansseq">
@@ -121,6 +122,34 @@
 
   <xsl:template match="d:command">
     <xsl:call-template name="inline.monoseq"/>
+  </xsl:template>
+
+  <xsl:template match="d:phrase">
+    <xsl:variable name="text-color">
+      <xsl:choose>
+        <xsl:when test="processing-instruction('dbsuse')">
+          <xsl:call-template name="get-suse-color">
+            <xsl:with-param name="value">
+              <xsl:call-template name="pi-attribute">
+                <xsl:with-param name="pis"
+                  select="processing-instruction('dbsuse')" />
+                <xsl:with-param name="attribute">color</xsl:with-param>
+              </xsl:call-template>
+            </xsl:with-param>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise/>
+      </xsl:choose>
+    </xsl:variable>
+
+    <span>
+      <xsl:if test="$text-color != ''">
+        <xsl:attribute name="style">
+          <xsl:value-of select="concat('color:', $text-color, ';')" />
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-imports />
+    </span>
   </xsl:template>
 
   <xsl:template match="d:productname">


### PR DESCRIPTION
This PR fixes #453 

Use `<?dbsuse color="..."?>` inside `<phrase>` or `<para>` or use the attribute `role="color:..."`. Currently, the following colors are supported:

* SUSE brand colors
  suse-jungle-green, suse-pine-green, suse-midnight-blue, suse-waterhole-blue, suse-mint, suse-persimmon, suse-fog
* "Typical" CSS color names
  aqua, black, blue, darkgray/darkgrey, fuchsia, gray/grey, green, lime, maroon, navy, olive, orange, purple, red, teal, white, yellow
* RGB colors
  with the syntax #RRGGBB (wheres R, G, and B are a single hex digits)

---

TODO after discussion with Jana (2022-05-31):

* [x] Disallow CSS color names and RGB colors
* [x] Define also shade SUSE colors

---

<details>
  <summary>Examples and screenshot</summary>

```xml
<phrase><?dbsuse color="suse-jungle-green"?>✓</phrase>
<phrase role="color:fuchsia">Hello</phrase>
<phrase><?dbsuse color="#aabbcc"?>Hello</phrase>
```

![Screenshot_20220525_144727](https://user-images.githubusercontent.com/1312925/170265493-e7f8fc99-5152-482c-be32-615facd5ec02.png)


</details>