### PR TITLE
Fix #455: Add missing strings for HTML output

### DIFF
--- a/suse2022-ns/common/l10n/ar.xml
+++ b/suse2022-ns/common/l10n/ar.xml
@@ -6,19 +6,107 @@
 <!-- FIXME: Check whether we need straight quotes everywhere, our Arabic SLE
 translators apparently want those. - sknorr, 2016-09-30 -->
 
+   <!--   <l:gentext key="LocalisedLanguageName" text="عربي"/>-->
    <l:gentext key="SeeAlso"         text="طالع أيضًا"/>
    <l:gentext key="Authors"         text="الكتاب"/>
    <l:gentext key="TableofContents" text="المحتويات"/>
    <l:gentext key="ListofAuthors"   text="قائمة المؤلفين"/>
+   <l:gentext key="Contributor"     text="&#1605;&#1587;&#1575;&#1607;&#1605;"/>
    <l:gentext key="Contributors"    text="المساهمون"/>
 
    <l:gentext key="admonseparator"  text=": "/>
 
-   <l:gentext key="Question" text="السؤال:"/>
-   <l:gentext key="question" text="السؤال:"/>
+   <l:gentext key="selectlanguage" text="ﺖﺣﺪﻳﺩ ﺎﻠﻠﻏﺓ"/>
+   <l:gentext key="selectformat" text="ﺖﺣﺪﻳﺩ ﺎﻠﺘﻨﺴﻴﻗ"/>
+   <l:gentext key="formathtml" text="ﺺﻔﺣﺎﺗ ﺎﻟﻮﻴﺑ" />
+   <l:gentext key="formatsinglehtml" text="ﺺﻔﺣﺓ ﻮﻴﺑ ﻢﻓﺭﺩﺓ" />
+   <l:gentext key="formatpdf" text="PDF" />
+   <l:gentext key="formatepub" text="ﻚﺗﺎﺑ ﺈﻠﻜﺗﺭﻮﻨﻳ (EPUB)" />
+   <l:gentext key="contentsoverview" text="ﺎﻠﻤﺤﺗﻮﻳﺎﺗ" />
+   <l:gentext key="showcontentsoverview" text="ﻉﺮﺿ ﺎﻠﻤﺤﺗﻮﻳﺎﺗ" />
+   <l:gentext key="find" text="ﺐﺤﺛ" />
 
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
+   <l:gentext key="navigation" text="التنقل"/>
+   <l:gentext key="moredocuments" text="المزيد من المستندات"/>
+
+   <l:gentext key="onthispage" text="ﻒﻳ ﻩﺬﻫ ﺎﻠﺼﻔﺣﺓ" />
+
+   <l:gentext key="givefeedback" text="ﺈﺑﺩﺍﺀ ﻡﻼﺤﻇﺎﺗ" />
+   <l:gentext key="reportbug" text="ﺍﻺﺑﻼﻏ ﻊﻧ ﻢﺸﻜﻟﺓ" />
+   <l:gentext key="editsource" text="ﺖﺣﺮﻳﺭ ﺎﻠﻤﺴﺘﻧﺩ ﺎﻠﻤﺻﺩﺭ" />
+
+   <l:gentext key="previouspage" text="ﺎﻠﺳﺎﺒﻗ" />
+   <l:gentext key="nextpage" text="ﺎﻠﺗﺎﻠﻳ" />
+
+   <l:gentext key="sharethispage" text="ﻢﺷﺍﺮﻛﺓ ﻩﺬﻫ ﺎﻠﺼﻔﺣﺓ" />
+   <l:gentext key="shareviafacebook" text="Facebook" />
+   <l:gentext key="sharevialinkedin" text="LinkedIn" />
+   <l:gentext key="shareviatwitter" text="Twitter" />
+   <l:gentext key="shareviaemail" text="ﺎﻠﺑﺮﻳﺩ ﺍﻺﻠﻜﺗﺭﻮﻨﻳ" />
+   <l:gentext key="printthispage" text="ﻂﺑﺎﻋﺓ ﻩﺬﻫ ﺎﻠﺼﻔﺣﺓ" />
+   <l:gentext key="susecareers" text="ﺎﻟﻮﻇﺎﺌﻓ" />
+   <l:gentext key="suselegal" text="ﺎﻠﺷﺅﻮﻧ ﺎﻠﻗﺎﻧﻮﻨﻳﺓ" />
+   <l:gentext key="suseabout" text="ﺡﻮﻟ" />
+   <l:gentext key="susecontact" text="ﺎﺘﺼﻟ ﺐﻧﺍ" />
+   <l:gentext key="version.info" text="ﺖﻨﻄﺒﻗ ﻊﻟﻯ " />
+   <l:gentext key="totopofpage" text="ﺄﻌﻟﻯ" />
+
+   <l:gentext key="version" text="ﺍﻺﺻﺩﺍﺭ" />
+   <l:gentext key="Version" text="ﺍﻺﺻﺩﺍﺭ" />
+
+   <l:gentext key="Question" text="السؤال:"/>
+   <l:gentext key="question" text="السؤال:"/>
+   <l:gentext key="LocalisedLanguageName" text="الإنجليزية" />
+   <l:gentext key="SeeAlso"         text="انظر أيضًا" />
+   <l:gentext key="Authors"         text="المؤلفون" />
+   <l:gentext key="TableofContents" text="المحتويات" />
+   <l:gentext key="ListofAuthors"   text="قائمة المؤلفين" />
+   <l:gentext key="Contributor"     text="المشارك في التحرير" />
+   <l:gentext key="Contributors"    text="المشاركون في التحرير" />
+
+   <l:gentext key="selectlanguage" text="تحديد اللغة" />
+   <l:gentext key="selectformat" text="تحديد التنسيق" />
+   <l:gentext key="formathtml" text="صفحات الويب" />
+   <l:gentext key="formatsinglehtml" text="صفحة ويب مفردة" />
+   <l:gentext key="formatpdf" text="PDF" />
+   <l:gentext key="formatepub" text="كتاب إلكتروني (EPUB)" />
+   <l:gentext key="contentsoverview" text="المحتويات" />
+   <l:gentext key="showcontentsoverview" text="عرض المحتويات" />
+   <l:gentext key="find" text="بحث" />
+
+   <l:gentext key="navigation" text="التنقل" />
+   <l:gentext key="moredocuments" text="المزيد من المستندات" />
+
+   <l:gentext key="onthispage" text="في هذه الصفحة" />
+
+   <l:gentext key="givefeedback" text="إبداء ملاحظات" />
+   <l:gentext key="reportbug" text="الإبلاغ عن مشكلة" />
+   <l:gentext key="editsource" text="تحرير المستند المصدر" />
+
+   <l:gentext key="previouspage" text="السابق" />
+   <l:gentext key="nextpage" text="التالي" />
+
+   <l:gentext key="sharethispage" text="مشاركة هذه الصفحة" />
+   <l:gentext key="shareviafacebook" text="Facebook" />
+   <l:gentext key="sharevialinkedin" text="LinkedIn" />
+   <l:gentext key="shareviatwitter" text="Twitter" />
+   <l:gentext key="shareviaemail" text="البريد الإلكتروني" />
+   <l:gentext key="printthispage" text="طباعة هذه الصفحة" />
+   <l:gentext key="susecareers" text="الوظائف" />
+   <l:gentext key="suselegal" text="الشؤون القانونية" />
+   <l:gentext key="suseabout" text="حول" />
+   <l:gentext key="susecontact" text="اتصل بنا" />
+   <l:gentext key="version.info" text="تنطبق على " />
+   <l:gentext key="totopofpage" text="أعلى" />
+
+   <l:gentext key="version" text="الإصدار" />
+   <l:gentext key="Version" text="الإصدار" />
+
+   <l:gentext key="step.optional" text="(اختياري)" />
+   <l:gentext key="GlossSeeAlso" text="انظر أيضًا" />
+   <l:gentext key="glossseealso" text="انظر أيضًا" />
    <!-- In most cases, this has to be empty -->
    <l:dingbat key="guimenustartquote" text=""/>
    <l:dingbat key="guimenuendquote" text=""/>
@@ -26,14 +114,16 @@ translators apparently want those. - sknorr, 2016-09-30 -->
    <l:dingbat key="startquote" text='"'/>
    <l:dingbat key="endquote" text='"'/>
 
-   <!-- FIXME: Needs translation. -->
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Jump to content"/>
-     <l:template name="bypass-to-nav" text="Jump to page navigation: previous page [access key p]/next page [access key n]"/>
+     <l:template name="bypass-to-content" text="الانتقال إلى المحتوى" />
+     <l:template name="bypass-to-nav" text="الانتقال إلى صفحة التنقل: الصفحة السابقة [زر الوصول p]/الصفحة التالية [زر الوصول n]" />
    </l:context>
 
+   <l:context name="glossary">
+     <l:template name="seealso" text="شاهد أيضًا %t." />
+   </l:context>
    <l:context name="styles">
-      <l:template name="person-name" text="الأول-الأخير"/>
+      <l:template name="person-name" text="first-last"/>
 
       <l:template name="example-label" text="المثال&#160;%n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/cs.xml
+++ b/suse2022-ns/common/l10n/cs.xml
@@ -10,9 +10,6 @@
    <l:gentext key="Contributors"    text="Přispěvatelé"/>
 
    <l:gentext key="admonseparator"  text=": "/>
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
 
    <l:gentext key="selectlanguage" text="Vybrat jazyk"/>
    <l:gentext key="selectformat" text="Vybrat formát"/>
@@ -27,22 +24,94 @@
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
    <l:gentext key="navigation" text="Navigace"/>
+   <l:gentext key="moredocuments" text="Více dokumentů"/>
+
+   <l:gentext key="onthispage" text="Na této straně"/>
+
+   <l:gentext key="givefeedback" text="Připomínkovat"/>
+   <l:gentext key="reportbug" text="Nahlásit problém"/>
+   <l:gentext key="editsource" text="Upravit zdrojový dokument"/>
+
+<!--   <l:gentext key="previouspage" text="Previous"/>-->
+<!--   <l:gentext key="nextpage" text="Next"/>-->
+
    <l:gentext key="sharethispage" text="Sdílet tuto stránku"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
    <l:gentext key="shareviatwitter" text="Twitter"/>
    <l:gentext key="shareviaemail" text="E-mail"/>
    <l:gentext key="printthispage" text="Vytisknout tuto stránku"/>
-   <l:gentext key="susecareers" text="Careers"/>
-   <l:gentext key="suselegal" text="Legal"/>
-   <l:gentext key="suseabout" text="About"/>
-   <l:gentext key="susecontact" text="Contact Us"/>
+   <l:gentext key="susecareers" text="Zaměstnání"/>
+   <l:gentext key="suselegal" text="Právní informace"/>
+   <l:gentext key="suseabout" text="O programu"/>
+   <l:gentext key="susecontact" text="Kontaktujte nás"/>
    <l:gentext key="version.info" text="Platí pro "/>
    <l:gentext key="totopofpage" text="Nahoru"/>
 
+   <l:gentext key="version" text="Verze"/>
+   <l:gentext key="Version" text="Verze"/>
+
+   <l:gentext key="step.optional" text="(Volitelné)"/>
+   <l:gentext key="GlossSeeAlso" text="Viz také"/>
+   <l:gentext key="glossseealso" text="Viz také"/>
+   <l:gentext key="SeeAlso"         text="Viz také" />
+   <l:gentext key="Authors"         text="Autoři" />
+   <l:gentext key="TableofContents" text="Obsah" />
+   <l:gentext key="ListofAuthors"   text="Seznam autorů" />
+   <l:gentext key="Contributor"     text="Přispěvatel" />
+   <l:gentext key="Contributors"    text="Přispěvatelé" />
+
+   <l:gentext key="selectlanguage" text="Vybrat jazyk" />
+   <l:gentext key="selectformat" text="Vybrat formát" />
+   <l:gentext key="formathtml" text="Webové stránky" />
+   <l:gentext key="formatsinglehtml" text="Jedna webová stránka" />
+   <l:gentext key="formatpdf" text="PDF" />
+   <l:gentext key="formatepub" text="E-kniha (EPUB)" />
+   <l:gentext key="contentsoverview" text="Obsah" />
+   <l:gentext key="showcontentsoverview" text="Zobrazit obsah" />
+   <l:gentext key="find" text="Hledání" />
+
+   <l:gentext key="runinhead.default.title.end.punct" text="." />
+
+   <l:gentext key="navigation" text="Navigace" />
+   <l:gentext key="moredocuments" text="Více dokumentů" />
+
+   <l:gentext key="onthispage" text="Na této straně" />
+
+   <l:gentext key="givefeedback" text="Připomínkovat" />
+   <l:gentext key="reportbug" text="Nahlásit problém" />
+   <l:gentext key="editsource" text="Upravit zdrojový dokument" />
+
+   <l:gentext key="previouspage" text="Předchozí" />
+   <l:gentext key="nextpage" text="Následující" />
+
+   <l:gentext key="sharethispage" text="Sdílet tuto stránku" />
+   <l:gentext key="shareviafacebook" text="Facebook" />
+   <l:gentext key="sharevialinkedin" text="LinkedIn" />
+   <l:gentext key="shareviatwitter" text="Twitter" />
+   <l:gentext key="shareviaemail" text="E-mail" />
+   <l:gentext key="printthispage" text="Vytisknout tuto stránku" />
+   <l:gentext key="susecareers" text="Zaměstnání" />
+   <l:gentext key="suselegal" text="Právní informace" />
+   <l:gentext key="suseabout" text="O programu" />
+   <l:gentext key="susecontact" text="Kontaktujte nás" />
+   <l:gentext key="version.info" text="Platí pro " />
+   <l:gentext key="totopofpage" text="Začátek" />
+
+   <l:gentext key="version" text="Verze" />
+   <l:gentext key="Version" text="Verze" />
+
+   <l:gentext key="step.optional" text="(Volitelné)" />
+   <l:gentext key="GlossSeeAlso" text="Viz také" />
+
+
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
+
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Jdi na obsah"/>
-     <l:template name="bypass-to-nav" text="Jdi na navigaci: předchozí stránka [klávesa p]/další stránka [klávesa n]"/>
+     <l:template name="bypass-to-content" text="Přeskočit na obsah" />
+     <l:template name="bypass-to-nav" text="Přeskočit na stránkovou navigaci: předchozí stránka [přístup klávesou p] / následující stránka [přístup klávesou n]" />
    </l:context>
 
    <l:context name="styles">
@@ -72,7 +141,7 @@
       <l:template name="sect3" text="&#268;&#225;st &#8222;%t&#8220;"/>
       <l:template name="sect4" text="&#268;&#225;st &#8222;%t&#8220;"/>
       <l:template name="sect5" text="&#268;&#225;st &#8222;%t&#8220;"/>
-      <l:template name="page.citation" text=" (strana&#160;%p)"/>
+      <l:template name="page.citation" text=" (str.&#160;%p)" />
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Článek „%t”"/>
@@ -103,7 +172,7 @@
       <l:template name="equation" style="nonumber"  text="Rovnice&#160;&#8222;%t&#8220;"/>
       <l:template name="example" style="nonumber"  text="P&#345;&#237;klad&#160;&#8222;%t&#8220;"/>
       <l:template name="figure" style="nonumber"  text="Obr&#225;zek&#160;&#8222;%t&#8220;"/>
-      <l:template name="part" style="nonumber"  text="Part&#160;&#8222;%t&#8220;"/>
+      <l:template name="part" style="nonumber"  text="Díl&#160;&#8222;%t&#8220;"/>
       <l:template name="procedure" style="nonumber"  text="Postup&#160;&#8222;%t&#8220;"/>
       <l:template name="productionset" style="nonumber"  text="V&#253;roba&#160;&#8222;%t&#8220;"/>
       <l:template name="qandadiv" style="nonumber"  text="Ot&#225;zky a odpov&#283;di&#160;&#8222;%t&#8220;"/>
@@ -150,7 +219,7 @@
    </l:context>
 
    <l:context name="title">
-      <l:template name="part" text="Part&#160;%n&#160;%t"/>
+      <l:template name="part" text="Díl&#160;%n „%t“" />
    </l:context>
 
 
@@ -174,7 +243,7 @@
       <l:template name="pageup" text="Page &#x02191;"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Shift"/>
-      <l:template name="space" text="Mezern&#237;k"/>
+      <l:template name="space" text="Space"/>
       <l:template name="tab" text="&#x02192;|"/>
       <l:template name="up" text="&#x02191;"/><!-- uarr -->
    </l:context>
@@ -185,7 +254,7 @@
    </l:context>
 
    <l:context name="datetime">
-     <l:template name="titlepage.format" text="d. B Y"/>
+     <l:template name="titlepage.format" text="d b Y"/>
    </l:context>
 
 </l:l10n>

--- a/suse2022-ns/common/l10n/da.xml
+++ b/suse2022-ns/common/l10n/da.xml
@@ -14,14 +14,6 @@
 
    <l:gentext key="admonseparator"  text=": "/>
 
-   <l:dingbat key="startquote" text="&#34;"/>
-   <l:dingbat key="endquote" text="&#34;"/>
-   <l:dingbat key="nestedstartquote" text="&#34;"/>
-   <l:dingbat key="nestedendquote" text="&#34;"/>
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-
    <l:gentext key="selectlanguage" text="Vælg sprog"/>
    <l:gentext key="selectformat" text="Vælg format"/>
    <l:gentext key="formathtml" text="Websider"/>
@@ -35,20 +27,44 @@
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
    <l:gentext key="navigation" text="Navigation"/>
+   <l:gentext key="moredocuments" text="Flere dokumenter"/>
+
+   <l:gentext key="onthispage" text="På denne side"/>
+
+   <l:gentext key="givefeedback" text="Giv feedback"/>
+   <l:gentext key="reportbug" text="Rapportere et problem"/>
+   <l:gentext key="editsource" text="Rediger kildedokument"/>
+
+<!--   <l:gentext key="previouspage" text="Previous"/>-->
+<!--   <l:gentext key="nextpage" text="Next"/>-->
+
    <l:gentext key="sharethispage" text="Del denne side"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
    <l:gentext key="shareviatwitter" text="Twitter"/>
    <l:gentext key="shareviaemail" text="E-mail"/>
    <l:gentext key="printthispage" text="Udskriv denne side"/>
-   <l:gentext key="susecareers" text="Careers"/>
-   <l:gentext key="suselegal" text="Legal"/>
-   <l:gentext key="suseabout" text="About"/>
-   <l:gentext key="susecontact" text="Contact Us"/>
+   <l:gentext key="susecareers" text="Job"/>
+   <l:gentext key="suselegal" text="Juridisk"/>
+   <l:gentext key="suseabout" text="Om"/>
+   <l:gentext key="susecontact" text="Kontakt os"/>
    <l:gentext key="version.info" text="Gælder for "/>
    <l:gentext key="totopofpage" text="Top"/>
 
+   <l:gentext key="version" text="Version"/>
+   <l:gentext key="Version" text="Version"/>
+
    <l:gentext key="step.optional" text="(Valgfit)"/>
+<!--   <l:gentext key="GlossSeeAlso" text="See also"/>-->
+<!--   <l:gentext key="glossseealso" text="See also"/>-->
+
+   <l:dingbat key="startquote" text="&#34;"/>
+   <l:dingbat key="endquote" text="&#34;"/>
+   <l:dingbat key="nestedstartquote" text="&#34;"/>
+   <l:dingbat key="nestedendquote" text="&#34;"/>
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
 
    <l:context name="bypass-block">
      <l:template name="bypass-to-content" text="Naviger til begyndelsen"/>

--- a/suse2022-ns/common/l10n/de.xml
+++ b/suse2022-ns/common/l10n/de.xml
@@ -4,16 +4,17 @@
         english-language-name="German">
 
    <l:gentext key="LocalisedLanguageName" text="Deutsch"/>
-   <l:gentext key="ListofAuthors" text="Autorenliste"/>
-   <l:gentext key="Authors"       text="Autoren"/>
-   <l:gentext key="Index"         text="Index"/>
-   <l:gentext key="index"         text="Index"/>
-   <l:gentext key="Contributor"     text="Mitwirkender"/>
-   <l:gentext key="Contributors"    text="Mitwirkende"/>
+   <l:gentext key="SeeAlso"         text="Siehe auch" />
+   <l:gentext key="Authors"         text="Autoren" />
+   <l:gentext key="TableofContents" text="Inhalt" />
+   <l:gentext key="ListofAuthors"   text="Autorenliste" />
+   <l:gentext key="Contributor"     text="Mitwirkender" />
+   <l:gentext key="Contributors"    text="Mitwirkende" />
+
    <l:gentext key="admonseparator"  text=": "/>
 
-   <l:gentext key="selectlanguage" text="Sprache wählen"/>
-   <l:gentext key="selectformat" text="Format wählen"/>
+   <l:gentext key="selectlanguage" text="Sprache auswählen"/>
+   <l:gentext key="selectformat" text="Format auswählen"/>
    <l:gentext key="formathtml" text="Webseiten"/>
    <l:gentext key="formatsinglehtml" text="Einzelne Webseite"/>
    <l:gentext key="formatpdf" text="PDF"/>
@@ -24,27 +25,37 @@
 
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
-   <l:gentext key="navigation" text="Navigation"/>
+   <l:gentext key="navigation" text="Navigation" />
+   <l:gentext key="moredocuments" text="Weitere Dokumente" />
 
-   <l:gentext key="onthispage" text="Auf dieser Seite"/>
+   <l:gentext key="onthispage" text="Auf dieser Seite" />
+
+   <l:gentext key="givefeedback" text="Feedback geben" />
+   <l:gentext key="reportbug" text="Problem melden" />
+   <l:gentext key="editsource" text="Quelldokument bearbeiten" />
+
+   <l:gentext key="previouspage" text="Zurück" />
+   <l:gentext key="nextpage" text="Weiter" />
 
    <l:gentext key="sharethispage" text="Diese Seite teilen"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
    <l:gentext key="shareviatwitter" text="Twitter"/>
    <l:gentext key="shareviaemail" text="E-Mail"/>
-   <l:gentext key="printthispage" text="Diese Seite drucken"/>
+   <l:gentext key="printthispage" text="Diese Seite ausdrucken"/>
    <l:gentext key="susecareers" text="Jobs"/>
-   <l:gentext key="suselegal" text="Rechtliche Hinweise/Impressum"/>
+   <l:gentext key="suselegal" text="Rechtliche Hinweise"/><!-- /Impressum -->
    <l:gentext key="suseabout" text="Über"/>
    <l:gentext key="susecontact" text="Kontakt"/>
-   <l:gentext key="version.info" text="Bezieht sich auf "/>
-   <l:gentext key="totopofpage" text="Seitenanfang"/>
+   <l:gentext key="version.info" text="Gilt für "/>
+   <l:gentext key="totopofpage" text="Oben"/>
 
    <l:gentext key="version" text="Version"/>
    <l:gentext key="Version" text="Version"/>
 
    <l:gentext key="step.optional" text="(Optional)"/>
+   <l:gentext key="GlossSeeAlso" text="Siehe auch" />
+   <l:gentext key="glossseealso" text="Siehe auch" />
 
    <!-- In most cases, this has to be empty -->
    <l:dingbat key="guimenustartquote" text=""/>
@@ -55,6 +66,10 @@
    <l:context name="bypass-block">
      <l:template name="bypass-to-content" text="Zum Inhalt springen"/>
      <l:template name="bypass-to-nav" text="Zur Seitennavigation springen: vorherige Seite [Zugriffstaste p]/nächste Seite [Zugriffstaste n]"/>
+   </l:context>
+
+   <l:context name="glossary">
+     <l:template name="seealso" text="Siehe auch %t." />
    </l:context>
 
    <l:context name="styles">

--- a/suse2022-ns/common/l10n/es.xml
+++ b/suse2022-ns/common/l10n/es.xml
@@ -5,8 +5,10 @@
         english-language-name="Spanish">
 
    <l:gentext key="LocalisedLanguageName" text="Espa&#241;ol"/>
-   <l:gentext key="ListofAuthors" text="Autores"/>
-   <l:gentext key="Authors"       text="Autores"/>
+   <l:gentext key="SeeAlso"         text="Consulte también" />
+   <l:gentext key="Authors"         text="Autores"/>
+   <l:gentext key="TableofContents" text="Contenido"/>
+   <l:gentext key="ListofAuthors"   text="Autores"/>
    <l:gentext key="Contributor"     text="Colaborador"/>
    <l:gentext key="Contributors"    text="Colaboradores"/>
 
@@ -15,16 +17,12 @@
    <l:gentext key="hyphenation-push-character-count" text="5"/>
    <l:gentext key="hyphenation-remain-character-count" text="5"/>
 
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-
    <l:gentext key="selectlanguage" text="Seleccionar idioma"/>
    <l:gentext key="selectformat" text="Seleccionar formato"/>
    <l:gentext key="formathtml" text="Páginas Web"/>
-   <l:gentext key="formatsinglehtml" text="Una página Web"/>
+   <l:gentext key="formatsinglehtml" text="Página Web única" />
    <l:gentext key="formatpdf" text="PDF"/>
-   <l:gentext key="formatepub" text="E-Book (EPUB)"/>
+   <l:gentext key="formatepub" text="Libro electrónico (ePUB)" />
    <l:gentext key="contentsoverview" text="Contenido"/>
    <l:gentext key="showcontentsoverview" text="Mostrar contenido"/>
    <l:gentext key="find" text="Buscar"/>
@@ -32,6 +30,17 @@
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
    <l:gentext key="navigation" text="Navegación"/>
+   <l:gentext key="moredocuments" text="Más documentos"/>
+
+   <l:gentext key="onthispage" text="En esta página"/>
+
+   <l:gentext key="givefeedback" text="Aportar comentarios" />
+   <l:gentext key="reportbug" text="Informar de un problema"/>
+   <l:gentext key="editsource" text="Editar documento de origen" />
+
+   <l:gentext key="previouspage" text="Anterior" />
+   <l:gentext key="nextpage" text="Siguiente" />
+
    <l:gentext key="sharethispage" text="Compartir esta página"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
@@ -49,12 +58,20 @@
    <l:gentext key="Version" text="Versión"/>
 
    <l:gentext key="step.optional" text="(Opcional)"/>
+   <l:gentext key="GlossSeeAlso" text="Consulte también" />
+   <l:gentext key="glossseealso" text="Consulte también" />
 
-   <l:gentext key="part" text="Parte"/>
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
 
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Saltar a contenido"/>
-     <l:template name="bypass-to-nav" text="Saltar a navegación de páginas: página anterior [tecla acceso p]/página siguiente [tecla acceso n]"/>
+     <l:template name="bypass-to-content" text="Ir al contenido" />
+     <l:template name="bypass-to-nav" text="Ir a la navegación de la página: página anterior [tecla de acceso p]/página siguiente [tecla de acceso n]" />
+   </l:context>
+
+   <l:context name="glossary">
+     <l:template name="seealso" text="Consulte también %t." />
    </l:context>
 
    <l:context name="styles">
@@ -202,7 +219,6 @@
       <l:template name="up" text="&#x02191;"/><!-- uarr -->
    </l:context>
 
-
    <l:context name="datetime-full">
      <l:template name="January" text="enero" lang="es" />
       <l:template name="February" text="febrero" lang="es" />
@@ -224,6 +240,6 @@
    </l:context>
 
    <l:context name="datetime">
-     <l:template name="titlepage.format" text="d/m/Y"/>
+     <l:template name="titlepage.format" text="d b Y"/>
    </l:context>
 </l:l10n>

--- a/suse2022-ns/common/l10n/fi.xml
+++ b/suse2022-ns/common/l10n/fi.xml
@@ -12,10 +12,6 @@
 
    <l:gentext key="admonseparator"  text=": "/>
 
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-
    <l:gentext key="selectlanguage" text="Valitse kieli"/>
    <l:gentext key="selectformat" text="Valitse muoto"/>
    <l:gentext key="formathtml" text="Web-sivut"/>
@@ -29,6 +25,17 @@
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
    <l:gentext key="navigation" text="Siirtyminen"/>
+   <l:gentext key="moredocuments" text="Lisää asiakirjoja"/>
+
+   <l:gentext key="onthispage" text="Tällä sivulla"/>
+
+   <l:gentext key="givefeedback" text="Anna palautetta"/>
+   <l:gentext key="reportbug" text="Ilmoita asiasta"/>
+   <l:gentext key="editsource" text="Muokkaa lähdeasiakirjaa"/>
+
+<!--   <l:gentext key="previouspage" text="Previous"/>-->
+<!--   <l:gentext key="nextpage" text="Next"/>-->
+
    <l:gentext key="sharethispage" text="Jaa tämä sivu"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
@@ -44,8 +51,8 @@
 
    <!-- FIXME: Needs translation. -->
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Jump to content"/>
-     <l:template name="bypass-to-nav" text="Jump to page navigation: previous page [access key p]/next page [access key n]"/>
+     <l:template name="bypass-to-content" text="Siirry sisältöön"/>
+     <l:template name="bypass-to-nav" text="Siirry sivun navigointiin: edellinen sivu [näppäin p]/seuraava sivu [näppäin n]"/>
    </l:context>
 
    <l:context name="styles">
@@ -162,6 +169,10 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
+
    <l:dingbat key="startquote" text="&#8221;"/>
    <l:dingbat key="endquote" text="&#8221;"/>
    <l:dingbat key="nestedstartquote" text="&#8221;"/>
@@ -172,7 +183,6 @@
    <l:context name="title">
       <l:template name="part" text="Osa&#160;%n&#160;%t"/>
    </l:context>
-
 
    <l:context name="msgset">
       <l:template name="alt" text="Alt"/>

--- a/suse2022-ns/common/l10n/fr.xml
+++ b/suse2022-ns/common/l10n/fr.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- $Id: fr.xml 43757 2009-08-24 08:14:29Z toms $ -->
 <l:l10n xmlns:l="http://docbook.sourceforge.net/xmlns/l10n/1.0"
         language="fr"
         english-language-name="French">
@@ -7,9 +6,8 @@
    <l:gentext key="LocalisedLanguageName" text="Fran&#231;ais"/>
    <l:gentext key="ListofAuthors" text="Auteurs"/>
    <l:gentext key="Authors"       text="Auteurs"/>
-   <l:gentext key="NOTE" text="REMARQUE"/>
-   <l:gentext key="Note" text="Remarque"/>
-   <l:gentext key="note" text="Remarque"/>
+   <l:gentext key="TableofContents" text="Table des matières" />
+   <l:gentext key="ListofAuthors"   text="Liste des auteurs" />
    <l:gentext key="Contributor"     text="Contributeur"/>
    <l:gentext key="Contributors"    text="Contributeurs"/>
 
@@ -18,20 +16,31 @@
    <l:gentext key="hyphenation-push-character-count" text="4"/>
    <l:gentext key="hyphenation-remain-character-count" text="4"/>
 
-   <l:gentext key="selectlanguage" text="Sélectionner la langue"/>
-   <l:gentext key="selectformat" text="Sélectionner le format"/>
-   <l:gentext key="formathtml" text="Pages Web"/>
-   <l:gentext key="formatsinglehtml" text="Page Web unique"/>
-   <l:gentext key="formatpdf" text="PDF"/>
-   <l:gentext key="formatepub" text="E-Book (EPUB)"/>
-   <l:gentext key="contentsoverview" text="Contenu"/>
-   <l:gentext key="showcontentsoverview" text="Afficher le contenu"/>
-   <l:gentext key="find" text="Rechercher"/>
+   <l:gentext key="selectlanguage" text="Sélectionner une langue" />
+   <l:gentext key="selectformat" text="Sélectionner un format" />
+   <l:gentext key="formathtml" text="Pages Web" />
+   <l:gentext key="formatsinglehtml" text="Page Web unique" />
+   <l:gentext key="formatpdf" text="PDF" />
+   <l:gentext key="formatepub" text="Livre électronique (EPUB)" />
+   <l:gentext key="contentsoverview" text="Table des matières" />
+   <l:gentext key="showcontentsoverview" text="Afficher la table des matières" />
+   <l:gentext key="find" text="Rechercher" />
 
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
-   <l:gentext key="navigation" text="Navigation"/>
-   <l:gentext key="sharethispage" text="Partager cette page"/>
+   <l:gentext key="navigation" text="Navigation" />
+   <l:gentext key="moredocuments" text="Plus de documents" />
+
+   <l:gentext key="onthispage" text="Sur cette page" />
+
+   <l:gentext key="givefeedback" text="Formuler des commentaires" />
+   <l:gentext key="reportbug" text="Signaler un problème" />
+   <l:gentext key="editsource" text="Modifier le document source" />
+
+   <l:gentext key="previouspage" text="Précédent" />
+   <l:gentext key="nextpage" text="Suivant" />
+
+   <l:gentext key="sharethispage" text="Partager cette page" />
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
    <l:gentext key="shareviatwitter" text="Twitter"/>
@@ -39,23 +48,30 @@
    <l:gentext key="printthispage" text="Imprimer cette page"/>
    <l:gentext key="susecareers" text="Carrières"/>
    <l:gentext key="suselegal" text="Mentions légales"/>
-   <l:gentext key="suseabout" text="Infos"/>
+   <l:gentext key="suseabout" text="À propos de" />
    <l:gentext key="susecontact" text="Contactez-nous"/>
    <l:gentext key="version.info" text="S'applique à "/>
-   <l:gentext key="totopofpage" text="Haut"/>
+   <l:gentext key="totopofpage" text="Haut de la page" />
 
    <l:gentext key="version" text="Version"/>
    <l:gentext key="Version" text="Version"/>
 
-   <l:gentext key="step.optional" text="(Optionnelle)"/>
+   <l:gentext key="step.optional" text="(Facultatif)" />
+   <l:gentext key="GlossSeeAlso" text="Reportez-vous également à la section" />
+   <l:gentext key="glossseealso" text="Reportez-vous également à la section" />
+
 
    <!-- In most cases, this has to be empty -->
    <l:dingbat key="guimenustartquote" text=""/>
    <l:dingbat key="guimenuendquote" text=""/>
 
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Passer au contenu"/>
-     <l:template name="bypass-to-nav" text="Passer à la navigation aux pages: page antérieure [touche directe p]/page suivante [touche directe n]"/>
+     <l:template name="bypass-to-content" text="Accéder au contenu" />
+     <l:template name="bypass-to-nav" text="Navigation Accéder à la page : page précédente [raccourci clavier p] / page suivante [raccourci clavier n]" />
+   </l:context>
+
+   <l:context name="glossary">
+     <l:template name="seealso" text="Voir aussi %t." />
    </l:context>
 
    <l:context name="styles">
@@ -182,7 +198,6 @@
       <l:template name="up" text="&#x02191;"/><!-- uarr -->
   </l:context>
 
-
    <l:context name="datetime-full">
       <l:template name="January" text="janvier" lang="fr" />
       <l:template name="February" text="f&#xe9;vrier" lang="fr" />
@@ -204,7 +219,8 @@
    </l:context>
 
    <l:context name="datetime">
-     <l:template name="titlepage.format" text="d/m/Y"/>
+     <l:template name="titlepage.format" text="d b Y"/>
    </l:context>
+
 
 </l:l10n>

--- a/suse2022-ns/common/l10n/hu.xml
+++ b/suse2022-ns/common/l10n/hu.xml
@@ -7,10 +7,10 @@
    <l:gentext key="LocalisedLanguageName" text="Magyar"/>
    <l:gentext key="SeeAlso"         text="L&#225;sd m&#233;g"/>
    <l:gentext key="Authors"         text="Szerz&#337;k"/>
-   <l:gentext key="TableofContents" text="Tartalomjegyz&#233;k"/>
-   <l:gentext key="ListofAuthors"   text="Szerz&#337;lista"/>
-   <l:gentext key="Contributor"     text="Szerző"/>
-   <l:gentext key="Contributors"    text="Szerzők"/>
+   <l:gentext key="TableofContents" text="Tartalom" />
+   <l:gentext key="ListofAuthors"   text="Szerzők listája" />
+   <l:gentext key="Contributor"     text="Közreműködő" />
+   <l:gentext key="Contributors"    text="Közreműködők" />
 
    <!-- Workaround for a bug in the original stylesheets -->
    <l:gentext key="PubDate" text="Kiadás dátuma"/>
@@ -18,40 +18,62 @@
 
    <l:gentext key="admonseparator"  text=": "/>
 
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-
-   <l:gentext key="selectlanguage" text="Nyelv választása"/>
-   <l:gentext key="selectformat" text="Formátum beállítása"/>
-   <l:gentext key="formathtml" text="Weboldalak"/>
-   <l:gentext key="formatsinglehtml" text="Egyetlen weboldal"/>
+   <l:gentext key="selectlanguage" text="Nyelv kiválasztása" />
+   <l:gentext key="selectformat" text="Formátum megadása" />
+   <l:gentext key="formathtml" text="Weblapok" />
+   <l:gentext key="formatsinglehtml" text="Egy weblap" />
    <l:gentext key="formatpdf" text="PDF"/>
-   <l:gentext key="formatepub" text="E-könyv (EPUB)"/>
+   <l:gentext key="formatepub" text="E-book (EPUB)" />
    <l:gentext key="contentsoverview" text="Tartalom"/>
    <l:gentext key="showcontentsoverview" text="Tartalom megjelenítése"/>
    <l:gentext key="find" text="Keresés"/>
 
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
-   <l:gentext key="navigation" text="Navigáció"/>
-   <l:gentext key="sharethispage" text="Az oldal megosztása"/>
+   <l:gentext key="navigation" text="Navigáció" />
+   <l:gentext key="moredocuments" text="Több dokumentum" />
+
+   <l:gentext key="onthispage" text="Ezen az oldalon" />
+
+   <l:gentext key="givefeedback" text="Visszajelzés küldése" />
+   <l:gentext key="reportbug" text="Probléma bejelentése" />
+   <l:gentext key="editsource" text="Forrásdokumentum szerkesztése" />
+
+   <l:gentext key="previouspage" text="Előző" />
+   <l:gentext key="nextpage" text="Következő" />
+
+   <l:gentext key="sharethispage" text="Oldal megosztása" />
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
    <l:gentext key="shareviatwitter" text="Twitter"/>
    <l:gentext key="shareviaemail" text="E-mail"/>
-   <l:gentext key="printthispage" text="Az oldal nyomtatása"/>
+   <l:gentext key="printthispage" text="Oldal nyomtatása" />
    <l:gentext key="susecareers" text="Állások"/>
    <l:gentext key="suselegal" text="Jogi"/>
    <l:gentext key="suseabout" text="Névjegy"/>
    <l:gentext key="susecontact" text="Lépjen velünk kapcsolatba"/>
-   <l:gentext key="version.info" text="Dokumentum tárgya: "/>
-   <l:gentext key="totopofpage" text="A tetejére"/>
+   <l:gentext key="version.info" text="Mire vonatkozik " />
+   <l:gentext key="totopofpage" text="Az oldal tetejére" />
 
-   <!-- FIXME: Needs translation. -->
+   <l:gentext key="version" text="Verzió" />
+   <l:gentext key="Version" text="Verzió" />
+
+   <l:gentext key="step.optional" text="(Opcionális)" />
+   <l:gentext key="GlossSeeAlso" text="Lásd még" />
+   <l:gentext key="glossseealso" text="Lásd még" />
+
+
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
+
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Jump to content"/>
-     <l:template name="bypass-to-nav" text="Jump to page navigation: previous page [access key p]/next page [access key n]"/>
+     <l:template name="bypass-to-content" text="Ugrás a tartalomra" />
+     <l:template name="bypass-to-nav" text="Ugrás az oldalnavigációra: előző oldal [p billentyű]/következő oldal [n billentyű]" />
+   </l:context>
+
+   <l:context name="glossary">
+     <l:template name="seealso" text="Lásd még: %t." />
    </l:context>
 
    <l:context name="styles">
@@ -222,7 +244,7 @@
    </l:context>
 
   <l:context name="datetime">
-     <l:template name="titlepage.format" text="d/m/Y"/>
+     <l:template name="titlepage.format" text="d b Y"/>
   </l:context>
 
 </l:l10n>

--- a/suse2022-ns/common/l10n/it.xml
+++ b/suse2022-ns/common/l10n/it.xml
@@ -5,26 +5,21 @@
         english-language-name="Italian">
 
    <l:gentext key="LocalisedLanguageName" text="Italiano"/>
-   <l:gentext key="ListofAuthors" text="Autori"/>
-   <l:gentext key="Authors"       text="Autori"/>
-   <l:gentext key="Contributor"   text="Collaboratore"/>
-   <l:gentext key="Contributors"  text="Collaboratori"/>
-   <l:gentext key="Warning" text="Avviso"/>
-   <l:gentext key="warning" text="avviso"/>
-   <l:gentext key="WARNING" text="AVVISO"/>
+   <l:gentext key="SeeAlso"         text="Vedi anche" />
+   <l:gentext key="Authors"         text="Autori" />
+   <l:gentext key="TableofContents" text="Contenuto" />
+   <l:gentext key="ListofAuthors"   text="Elenco degli autori" />
+   <l:gentext key="Contributor"     text="Collaboratore" />
+   <l:gentext key="Contributors"    text="Collaboratori" />
 
    <l:gentext key="admonseparator"  text=": "/>
 
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-
-   <l:gentext key="selectlanguage" text="Selezione della lingua"/>
-   <l:gentext key="selectformat" text="Selezione del formato"/>
+   <l:gentext key="selectlanguage" text="Seleziona lingua" />
+   <l:gentext key="selectformat" text="Seleziona formato" />
    <l:gentext key="formathtml" text="Pagine Web"/>
-   <l:gentext key="formatsinglehtml" text="Pagina Web singola"/>
+   <l:gentext key="formatsinglehtml" text="Singola pagina Web" />
    <l:gentext key="formatpdf" text="PDF"/>
-   <l:gentext key="formatepub" text="E-Book (EPUB)"/>
+   <l:gentext key="formatepub" text="E-book (EPUB)" />
    <l:gentext key="contentsoverview" text="Contenuto"/>
    <l:gentext key="showcontentsoverview" text="Mostra contenuto"/>
    <l:gentext key="find" text="Trova"/>
@@ -32,28 +27,49 @@
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
    <l:gentext key="navigation" text="Navigazione"/>
-   <l:gentext key="sharethispage" text="Condividi pagina"/>
+   <l:gentext key="moredocuments" text="Altri documenti" />
+
+   <l:gentext key="onthispage" text="In questa pagina" />
+
+   <l:gentext key="givefeedback" text="Esprimi la tua opinione" />
+   <l:gentext key="reportbug" text="Segnala un problema" />
+   <l:gentext key="editsource" text="Modifica il documento sorgente" />
+
+   <l:gentext key="previouspage" text="Indietro" />
+   <l:gentext key="nextpage" text="Avanti" />
+
+   <l:gentext key="sharethispage" text="Condividi questa pagina" />
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
    <l:gentext key="shareviatwitter" text="Twitter"/>
    <l:gentext key="shareviaemail" text="E-mail"/>
-   <l:gentext key="printthispage" text="Stampa pagina"/>
+   <l:gentext key="printthispage" text="Stampa questa pagina" />
    <l:gentext key="susecareers" text="Opportunità di lavoro"/>
-   <l:gentext key="suselegal" text="Informazioni legali"/>
+   <l:gentext key="suselegal" text="Note legali" />
    <l:gentext key="suseabout" text="Informazioni"/>
-   <l:gentext key="susecontact" text="Contattateci"/>
+   <l:gentext key="susecontact" text="Contattaci" />
    <l:gentext key="version.info" text="Si applica a "/>
-   <l:gentext key="totopofpage" text="Su"/>
+   <l:gentext key="totopofpage" text="Inizio pagina" />
 
    <l:gentext key="version" text="Versione"/>
    <l:gentext key="Version" text="Versione"/>
 
    <l:gentext key="step.optional" text="(Opzionale)"/>
+   <l:gentext key="GlossSeeAlso" text="Vedi anche" />
+   <l:gentext key="glossseealso" text="Vedi anche" />
 
-   <!-- FIXME: Needs translation. -->
+
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
+
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Saltar al contenuto"/>
-     <l:template name="bypass-to-nav" text="Saltar alla navigazione delle pagine: pagina precedente [chiave d’accesso p]/pagina successiva [chiave d’accesso n]"/>
+     <l:template name="bypass-to-content" text="Vai al contenuto" />
+     <l:template name="bypass-to-nav" text="Naviga tra le pagine: pagina precedente [tasto di scelta p]/pagina successiva [tasto di scelta n]" />
+   </l:context>
+
+   <l:context name="glossary">
+     <l:template name="seealso" text="Vedi anche %t." />
    </l:context>
 
    <l:context name="styles">
@@ -217,6 +233,7 @@
    </l:context>
 
    <l:context name="datetime">
-     <l:template name="titlepage.format" text="d/m/Y"/>
+     <l:template name="titlepage.format" text="d b Y"/>
    </l:context>
+
 </l:l10n>

--- a/suse2022-ns/common/l10n/ja.xml
+++ b/suse2022-ns/common/l10n/ja.xml
@@ -4,30 +4,39 @@
         english-language-name="Japanese">
 
    <l:gentext key="LocalisedLanguageName" text="&#26085;&#26412;&#35486;"/>
-   <l:gentext key="Authors" text="著者"/>
-   <l:gentext key="ListofAuthors" text="&#33879;&#32773;"/>
-   <l:gentext key="TableofContents" text="&#30446;&#27425;"/>
-   <l:gentext key="Contributor"     text="コントリビュータ"/>
-   <l:gentext key="Contributors"    text="コントリビュータ"/>
+   <l:gentext key="SeeAlso"         text="関連項目" />
+   <l:gentext key="Authors"         text="著者" />
+   <l:gentext key="TableofContents" text="目次" />
+   <l:gentext key="ListofAuthors"   text="著者のリスト" />
+   <l:gentext key="Contributor"     text="寄稿者" />
+   <l:gentext key="Contributors"    text="寄稿者" />
 
    <l:gentext key="admonseparator"  text=": "/>
-
-   <l:dingbat key="guimenustartquote" text="&#65339;"/>
-   <l:dingbat key="guimenuendquote" text="&#65341;"/>
 
    <l:gentext key="selectlanguage" text="言語の選択"/>
    <l:gentext key="selectformat" text="フォーマットの選択"/>
    <l:gentext key="formathtml" text="Webページ"/>
    <l:gentext key="formatsinglehtml" text="単一のWebページ"/>
    <l:gentext key="formatpdf" text="PDF"/>
-   <l:gentext key="formatepub" text="電子書籍(EPUB)"/>
-   <l:gentext key="contentsoverview" text="コンテンツ"/>
-   <l:gentext key="showcontentsoverview" text="コンテンツの表示"/>
+   <l:gentext key="formatepub" text="Eブック(EPUB)" />
+   <l:gentext key="contentsoverview" text="目次" />
+   <l:gentext key="showcontentsoverview" text="目次を表示" />
    <l:gentext key="find" text="検索"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="&#xff1a;"/>
+   <l:gentext key="runinhead.default.title.end.punct" text="." />
 
    <l:gentext key="navigation" text="ナビゲーション"/>
+   <l:gentext key="moredocuments" text="その他のドキュメント" />
+
+   <l:gentext key="onthispage" text="このページで" />
+
+   <l:gentext key="givefeedback" text="フィードバック" />
+   <l:gentext key="reportbug" text="問題の報告" />
+   <l:gentext key="editsource" text="ソースドキュメントの編集" />
+
+   <l:gentext key="previouspage" text="前へ" />
+   <l:gentext key="nextpage" text="次へ" />
+
    <l:gentext key="sharethispage" text="このページを共有"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
@@ -36,15 +45,30 @@
    <l:gentext key="printthispage" text="このページを印刷"/>
    <l:gentext key="susecareers" text="採用情報"/>
    <l:gentext key="suselegal" text="利用条件"/>
-   <l:gentext key="suseabout" text="会社情報"/>
+   <l:gentext key="suseabout" text="バージョン情報" />
    <l:gentext key="susecontact" text="お問い合わせ先"/>
-   <l:gentext key="version.info" text="適用先"/>
+   <l:gentext key="version.info" text="適用項目 " />
    <l:gentext key="totopofpage" text="トップへ"/>
 
-   <!-- FIXME: Needs translation. -->
+   <l:gentext key="version" text="バージョン" />
+   <l:gentext key="Version" text="バージョン" />
+
+   <l:gentext key="step.optional" text="(オプション)" />
+   <l:gentext key="GlossSeeAlso" text="関連項目" />
+   <l:gentext key="glossseealso" text="関連項目" />
+
+
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
+
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Jump to content"/>
-     <l:template name="bypass-to-nav" text="Jump to page navigation: previous page [access key p]/next page [access key n]"/>
+     <l:template name="bypass-to-content" text="目次にジャンプ" />
+     <l:template name="bypass-to-nav" text="ページナビゲーションにジャンプ: 前のページ[アクセスキーp]/次のページ[アクセスキーn]" />
+   </l:context>
+
+   <l:context name="glossary">
+     <l:template name="seealso" text="%tも参照してください。" />
    </l:context>
 
    <l:context name="styles">

--- a/suse2022-ns/common/l10n/ko.xml
+++ b/suse2022-ns/common/l10n/ko.xml
@@ -4,21 +4,18 @@
         english-language-name="Korean">
 
    <l:gentext key="LocalisedLanguageName" text="&#54620;&#44397;&#50612;"/>
-   <l:gentext key="SeeAlso"         text="&#52280;&#51312;"/>
-   <l:gentext key="Authors"         text="&#51089;&#49457;&#51088;"/>
+   <l:gentext key="SeeAlso"         text="추가 보기" />
+   <l:gentext key="Authors"         text="원저자" />
    <l:gentext key="TableofContents" text="&#47785;&#52264;"/>
-   <l:gentext key="ListofAuthors" text="&#51200;&#51088; &#47785;&#47197;"/>
+   <l:gentext key="ListofAuthors"   text="원저자 목록" />
    <l:gentext key="Contributor"     text="기여자"/>
    <l:gentext key="Contributors"    text="기여자"/>
 
    <l:gentext key="admonseparator"  text=": "/>
 
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-
    <l:gentext key="PubDate" text="게시일"/>
    <l:gentext key="pubdate" text="게시일"/>
+
    <l:gentext key="selectlanguage" text="언어 선택"/>
    <l:gentext key="selectformat" text="형식 선택"/>
    <l:gentext key="formathtml" text="웹 페이지"/>
@@ -32,26 +29,49 @@
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
    <l:gentext key="navigation" text="탐색"/>
+   <l:gentext key="moredocuments" text="문서 더 보기" />
+
+   <l:gentext key="onthispage" text="이 페이지에서" />
+
+   <l:gentext key="givefeedback" text="피드백 제공" />
+   <l:gentext key="reportbug" text="문제 신고" />
+   <l:gentext key="editsource" text="소스 문서 편집" />
+
+   <l:gentext key="previouspage" text="이전" />
+   <l:gentext key="nextpage" text="다음" />
+
    <l:gentext key="sharethispage" text="이 페이지 공유"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
    <l:gentext key="shareviatwitter" text="Twitter"/>
    <l:gentext key="shareviaemail" text="전자 메일"/>
    <l:gentext key="printthispage" text="이 페이지 인쇄"/>
-   <l:gentext key="susecareers" text="Careers"/>
-   <l:gentext key="suselegal" text="Legal"/>
-   <l:gentext key="suseabout" text="About"/>
-   <l:gentext key="susecontact" text="Contact Us"/>
-   <l:gentext key="version.info" text="적용 대상 "/>
-   <l:gentext key="totopofpage" text="맨 위로"/>
+   <l:gentext key="susecareers" text="커리어" />
+   <l:gentext key="suselegal" text="법률" />
+   <l:gentext key="suseabout" text="정보" />
+   <l:gentext key="susecontact" text="문의하기" />
+   <l:gentext key="version.info" text="다음에 적용 " />
+   <l:gentext key="totopofpage" text="상위" />
 
-<!-- edited from docbook version-->
-   <l:gentext key="TIP" text="[&#52628;&#44032;&#32;&#51221;&#48372;]"/><l:gentext key="WARNING" text="&#51452;&#51032;"/>
+   <l:gentext key="version" text="버전" />
+   <l:gentext key="Version" text="버전" />
 
-   <!-- FIXME: Needs translation. -->
+   <l:gentext key="step.optional" text="(선택 사항)" />
+   <l:gentext key="GlossSeeAlso" text="추가 보기" />
+   <l:gentext key="glossseealso" text="추가 보기" />
+
+
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
+
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Jump to content"/>
-     <l:template name="bypass-to-nav" text="Jump to page navigation: previous page [access key p]/next page [access key n]"/>
+     <l:template name="bypass-to-content" text="목차로 이동" />
+     <l:template name="bypass-to-nav" text="페이지 탐색으로 이동: 이전 페이지 [액세스 키 p]/다음 페이지 [액세스 키 n]" />
+   </l:context>
+
+   <l:context name="glossary">
+     <l:template name="seealso" text="%t 추가 보기" />
    </l:context>
 
    <l:context name="styles">
@@ -182,7 +202,7 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
-   <l:context name="msgset"><!-- FIXME: What are the Japanese keycaps? -->
+   <l:context name="msgset">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/><!-- mdash -->
       <l:template name="command" text="&#x2318;"/>
@@ -228,7 +248,7 @@
    </l:context>
 
    <l:context name="datetime">
-     <l:template name="titlepage.format" text="m/d/Y"/>
+     <l:template name="titlepage.format" text="d b Y"/>
    </l:context>
 
 </l:l10n>

--- a/suse2022-ns/common/l10n/lt_lt.xml
+++ b/suse2022-ns/common/l10n/lt_lt.xml
@@ -13,12 +13,6 @@
 
    <l:gentext key="admonseparator"  text=": "/>
 
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-   <l:dingbat key="startquote" text="&#8222;"/>
-   <l:dingbat key="endquote" text="&#8220;"/>
-
    <l:gentext key="selectlanguage" text="Pasirinkti kalbą"/>
    <l:gentext key="selectformat" text="Pasirinkti formatą"/>
    <l:gentext key="formathtml" text="Tinklalapiai"/>
@@ -32,6 +26,17 @@
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
    <l:gentext key="navigation" text="Naršymas"/>
+   <l:gentext key="moredocuments" text="More documents"/>
+
+   <l:gentext key="onthispage" text="On this page"/>
+
+   <l:gentext key="givefeedback" text="Give feedback"/>
+   <l:gentext key="reportbug" text="Report an issue"/>
+   <l:gentext key="editsource" text="Edit source document"/>
+
+   <l:gentext key="previouspage" text="Previous"/>
+   <l:gentext key="nextpage" text="Next"/>
+
    <l:gentext key="sharethispage" text="Bendrinti šį puslapį"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
@@ -45,6 +50,12 @@
    <l:gentext key="version.info" text="Skirta"/>
    <l:gentext key="totopofpage" text="Viršus"/>
 
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
+   <l:dingbat key="startquote" text="&#8222;"/>
+   <l:dingbat key="endquote" text="&#8220;"/>
+   
    <!-- FIXME: Needs translation. -->
    <l:context name="bypass-block">
      <l:template name="bypass-to-content" text="Jump to content"/>

--- a/suse2022-ns/common/l10n/nl.xml
+++ b/suse2022-ns/common/l10n/nl.xml
@@ -16,17 +16,6 @@
 
    <l:gentext key="admonseparator"  text=": "/>
 
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-
-   <l:dingbat key="startquote" text="&#34;"/>
-   <l:dingbat key="endquote" text="&#34;"/>
-   <l:dingbat key="nestedstartquote" text="&#34;"/>
-   <l:dingbat key="nestedendquote" text="&#34;"/>
-   <l:dingbat key="singlestartquote" text="&#34;" lang="nl"/>
-   <l:dingbat key="singleendquote" text="&#34;" lang="nl"/>
-
    <l:gentext key="selectlanguage" text="Taal selecteren"/>
    <l:gentext key="selectformat" text="Indeling selecteren"/>
    <l:gentext key="formathtml" text="Webpagina's"/>
@@ -40,6 +29,17 @@
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
    <l:gentext key="navigation" text="Navigatie"/>
+   <l:gentext key="moredocuments" text="More documents"/>
+
+   <l:gentext key="onthispage" text="On this page"/>
+
+   <l:gentext key="givefeedback" text="Give feedback"/>
+   <l:gentext key="reportbug" text="Report an issue"/>
+   <l:gentext key="editsource" text="Edit source document"/>
+
+   <l:gentext key="previouspage" text="Previous"/>
+   <l:gentext key="nextpage" text="Next"/>
+
    <l:gentext key="sharethispage" text="Deze pagina delen"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
@@ -52,6 +52,17 @@
    <l:gentext key="susecontact" text="Contact met ons opnemen"/>
    <l:gentext key="version.info" text="Van toepassing op "/>
    <l:gentext key="totopofpage" text="Boven"/>
+
+  <!-- In most cases, this has to be empty -->
+  <l:dingbat key="guimenustartquote" text=""/>
+  <l:dingbat key="guimenuendquote" text=""/>
+
+  <l:dingbat key="startquote" text="&#34;"/>
+  <l:dingbat key="endquote" text="&#34;"/>
+  <l:dingbat key="nestedstartquote" text="&#34;"/>
+  <l:dingbat key="nestedendquote" text="&#34;"/>
+  <l:dingbat key="singlestartquote" text="&#34;" lang="nl"/>
+  <l:dingbat key="singleendquote" text="&#34;" lang="nl"/>
 
    <!-- FIXME: Needs translation. -->
    <l:context name="bypass-block">

--- a/suse2022-ns/common/l10n/no.xml
+++ b/suse2022-ns/common/l10n/no.xml
@@ -12,10 +12,6 @@
 
    <l:gentext key="admonseparator"  text=": "/>
 
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-
    <l:gentext key="selectlanguage" text="Velg språk"/>
    <l:gentext key="selectformat" text="Velg format"/>
    <l:gentext key="formathtml" text="Websider"/>
@@ -29,6 +25,17 @@
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
    <l:gentext key="navigation" text="Navigasjon"/>
+   <l:gentext key="moredocuments" text="More documents"/>
+
+   <l:gentext key="onthispage" text="On this page"/>
+
+   <l:gentext key="givefeedback" text="Give feedback"/>
+   <l:gentext key="reportbug" text="Report an issue"/>
+   <l:gentext key="editsource" text="Edit source document"/>
+
+   <l:gentext key="previouspage" text="Previous"/>
+   <l:gentext key="nextpage" text="Next"/>
+
    <l:gentext key="sharethispage" text="Del denne siden"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
@@ -41,6 +48,15 @@
    <l:gentext key="susecontact" text="Contact Us"/>
    <l:gentext key="version.info" text="Gjelder "/>
    <l:gentext key="totopofpage" text="Øverst"/>
+
+   <l:gentext key="version" text="Version"/>
+   <l:gentext key="Version" text="Version"/>
+
+   <l:gentext key="step.optional" text="(Optional)"/>
+
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
 
    <!-- FIXME: Needs translation. -->
    <l:context name="bypass-block">

--- a/suse2022-ns/common/l10n/pl.xml
+++ b/suse2022-ns/common/l10n/pl.xml
@@ -3,51 +3,71 @@
    language="pl" english-language-name="Polish">
 
    <l:gentext key="LocalisedLanguageName" text="Polski"/>
-   <l:gentext key="SeeAlso" text="Zobacz także"/>
+   <l:gentext key="SeeAlso" text="Patrz również" />
    <l:gentext key="Authors" text="Autorzy"/>
-   <l:gentext key="TableofContents" text="Spis treści"/>
+   <l:gentext key="TableofContents" text="Treść" />
    <l:gentext key="ListofAuthors" text="Lista autorów"/>
-   <!-- The following two may need better translation. Google Translate does
-        the same though. -->
-   <l:gentext key="Contributor"     text="Autor"/>
-   <l:gentext key="Contributors"    text="Autorzy"/>
+   <l:gentext key="Contributor"     text="Współautor" />
+   <l:gentext key="Contributors"    text="Współautorzy" />
 
    <l:gentext key="admonseparator"  text=": "/>
 
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-
    <l:gentext key="selectlanguage" text="Wybierz język"/>
    <l:gentext key="selectformat" text="Wybierz format"/>
-   <l:gentext key="formathtml" text="Strony WWW"/>
-   <l:gentext key="formatsinglehtml" text="Pojedyncza strona WWW"/>
+   <l:gentext key="formathtml" text="Strony sieci Web" />
+   <l:gentext key="formatsinglehtml" text="Pojedyncza strona sieci Web" />
    <l:gentext key="formatpdf" text="PDF"/>
    <l:gentext key="formatepub" text="E-book (EPUB)"/>
-   <l:gentext key="contentsoverview" text="Spis treści"/>
-   <l:gentext key="showcontentsoverview" text="Pokaż spis treści"/>
+   <l:gentext key="contentsoverview" text="Treść" />
+   <l:gentext key="showcontentsoverview" text="Pokaż treść" />
    <l:gentext key="find" text="Znajdź"/>
 
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
    <l:gentext key="navigation" text="Nawigacja"/>
+   <l:gentext key="moredocuments" text="Więcej dokumentów" />
+
+   <l:gentext key="onthispage" text="Na tej stronie" />
+
+   <l:gentext key="givefeedback" text="Przekaż opinię" />
+   <l:gentext key="reportbug" text="Zgłoś problem" />
+   <l:gentext key="editsource" text="Edytuj dokument źródłowy" />
+
+   <l:gentext key="previouspage" text="Poprzednia" />
+   <l:gentext key="nextpage" text="Następna" />
+
    <l:gentext key="sharethispage" text="Udostępnij tę stronę"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
    <l:gentext key="shareviatwitter" text="Twitter"/>
-   <l:gentext key="shareviaemail" text="E-mail"/>
+   <l:gentext key="shareviaemail" text="Wiadomość e-mail" />
    <l:gentext key="printthispage" text="Drukuj tę stronę"/>
-   <l:gentext key="susecareers" text="Kariera"/>
-   <l:gentext key="suselegal" text="Aspekty prawne"/>
+   <l:gentext key="susecareers" text="Praca" />
+   <l:gentext key="suselegal" text="Informacje prawne" />
    <l:gentext key="suseabout" text="Informacje"/>
    <l:gentext key="susecontact" text="Skontaktuj się z nami"/>
-   <l:gentext key="version.info" text="Drukuj tę stronę"/>
-   <l:gentext key="totopofpage" text="Do góry"/>
+   <l:gentext key="version.info" text="Dotyczy " />
+   <l:gentext key="totopofpage" text="Góra" />
 
-   <!-- FIXME: Needs translation. -->
+   <l:gentext key="version" text="Wersja" />
+   <l:gentext key="Version" text="Wersja" />
+
+   <l:gentext key="step.optional" text="(Opcjonalnie)" />
+   <l:gentext key="GlossSeeAlso" text="Patrz również" />
+   <l:gentext key="glossseealso" text="Patrz również" />
+
+
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
+
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Jump to content"/>
-     <l:template name="bypass-to-nav" text="Jump to page navigation: previous page [access key p]/next page [access key n]"/>
+     <l:template name="bypass-to-content" text="Przejdź do treści" />
+     <l:template name="bypass-to-nav" text="Przejdź do nawigacji na stronie: poprzednia strona [access key p] / następna strona [access key n]" />
+   </l:context>
+
+   <l:context name="glossary">
+     <l:template name="seealso" text="Patrz również %t." />
    </l:context>
 
    <l:context name="styles">
@@ -178,7 +198,7 @@
       <l:template name="pageup" text="Page &#x02191;"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Shift"/>
-      <l:template name="space" text="Spacja"/>
+      <l:template name="space" text="Space"/>
       <l:template name="tab" text="&#x02192;|"/>
       <l:template name="up" text="&#x02191;"/><!-- uarr -->
    </l:context>

--- a/suse2022-ns/common/l10n/pt_br.xml
+++ b/suse2022-ns/common/l10n/pt_br.xml
@@ -1,34 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Id: pt_br.xml 43757 2009-08-24 08:14:29Z toms $ -->
-<l:l10n xmlns:l="http://docbook.sourceforge.net/xmlns/l10n/1.0" language="pt_br" english-language-name="Portuguese (Brazil)">
-
+<l:l10n xmlns:l="http://docbook.sourceforge.net/xmlns/l10n/1.0"
+   language="pt_br" english-language-name="Portuguese (Brazil)">
 
    <l:gentext key="LocalisedLanguageName" text="Portugu&#234;s (Brasil)"/>
-   <l:gentext key="SeeAlso" text="Veja tamb&#233;m"/>
-   <l:gentext key="TableofContents" text="Sum&#225;rio"/>
+   <l:gentext key="SeeAlso" text="Consulte também" />
+   <l:gentext key="Authors"         text="Autores" />
+   <l:gentext key="TableofContents" text="Conteúdo" />
    <l:gentext key="ListofAuthors" text="Lista de Autores"/>
    <l:gentext key="Contributor"     text="Colaborador"/>
    <l:gentext key="Contributors"    text="Colaboradores"/>
 
    <l:gentext key="admonseparator"  text=": "/>
 
-   <!-- In most cases, this has to be empty -->
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-
    <l:gentext key="selectlanguage" text="Selecionar Idioma"/>
    <l:gentext key="selectformat" text="Selecionar Formato"/>
    <l:gentext key="formathtml" text="Páginas da Web"/>
    <l:gentext key="formatsinglehtml" text="Página da Web Única"/>
    <l:gentext key="formatpdf" text="PDF"/>
-   <l:gentext key="formatepub" text="E-book (EPUB)"/>
+   <l:gentext key="formatepub" text="E-Book (EPUB)" />
    <l:gentext key="contentsoverview" text="Conteúdo"/>
    <l:gentext key="showcontentsoverview" text="Mostrar Conteúdo"/>
-   <l:gentext key="find" text="Localizar"/>
+   <l:gentext key="find" text="Encontrar" />
 
    <l:gentext key="runinhead.default.title.end.punct" text="."/>
 
    <l:gentext key="navigation" text="Navegação"/>
+   <l:gentext key="moredocuments" text="Mais documentos" />
+
+   <l:gentext key="onthispage" text="Nesta página" />
+
+   <l:gentext key="givefeedback" text="Enviar comentários" />
+   <l:gentext key="reportbug" text="Relatar um problema" />
+   <l:gentext key="editsource" text="Editar documento de origem" />
+
+   <l:gentext key="previouspage" text="Anterior" />
+   <l:gentext key="nextpage" text="Próximo" />
+
    <l:gentext key="sharethispage" text="Compartilhar esta página"/>
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
@@ -38,20 +46,29 @@
    <l:gentext key="susecareers" text="Carreiras"/>
    <l:gentext key="suselegal" text="Jurídico"/>
    <l:gentext key="suseabout" text="Sobre"/>
-   <l:gentext key="susecontact" text="Entre em contato conosco"/>
+   <l:gentext key="susecontact" text="Contacte-nos" />
    <l:gentext key="version.info" text="Aplica-se a "/>
    <l:gentext key="totopofpage" text="Topo"/>
 
    <l:gentext key="version" text="Versão"/>
    <l:gentext key="Version" text="Versão"/>
 
-   <l:gentext key="step" text="etapa"/>
-   <l:gentext key="Step" text="Etapa"/>
+   <l:gentext key="step.optional" text="(Opcional)" />
+   <l:gentext key="GlossSeeAlso" text="Consulte também" />
+   <l:gentext key="glossseealso" text="Consulte também" />
 
-   <!-- FIXME: Needs translation. -->
+
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
+
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Jump to content"/>
-     <l:template name="bypass-to-nav" text="Jump to page navigation: previous page [access key p]/next page [access key n]"/>
+     <l:template name="bypass-to-content" text="Ir para o conteúdo" />
+     <l:template name="bypass-to-nav" text="Ir para navegação de página: página anterior [tecla de acesso p]/próxima página [tecla de acesso n]" />
+   </l:context>
+
+   <l:context name="glossary">
+     <l:template name="seealso" text="Consulte também %t." />
    </l:context>
 
    <l:context name="styles">

--- a/suse2022-ns/common/l10n/ru.xml
+++ b/suse2022-ns/common/l10n/ru.xml
@@ -3,53 +3,71 @@
 
 
    <l:gentext key="LocalisedLanguageName" text="Русский"/>
-   <l:gentext key="SeeAlso"         text="Смотрите также"/>
+   <l:gentext key="SeeAlso"         text="См. также" />
    <l:gentext key="Authors"         text="Авторы"/>
    <l:gentext key="TableofContents" text="Содержание"/>
    <l:gentext key="ListofAuthors"   text="Список авторов"/>
    <l:gentext key="Contributor"     text="Участник"/>
    <l:gentext key="Contributors"    text="Участники"/>
 
-   <l:gentext key="admonseparator"  text=": "/>
+   <l:gentext key="admonseparator"  text="! " />
+
+   <l:gentext key="selectlanguage" text="Выбрать язык" />
+   <l:gentext key="selectformat" text="Выбрать формат" />
+   <l:gentext key="formathtml" text="Веб-страницы"/>
+   <l:gentext key="formatsinglehtml" text="Одна веб-страница" />
+   <l:gentext key="formatpdf" text="PDF"/>
+   <l:gentext key="formatepub" text="Эл. книга (EPUB)" />
+   <l:gentext key="contentsoverview" text="Содержание"/>
+   <l:gentext key="showcontentsoverview" text="Показать содержание"/>
+   <l:gentext key="find" text="Поиск" />
+
+   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+
+   <l:gentext key="navigation" text="Навигация"/>
+   <l:gentext key="moredocuments" text="Еще документы" />
+
+   <l:gentext key="onthispage" text="На странице" />
+
+   <l:gentext key="givefeedback" text="Оставить отзыв" />
+   <l:gentext key="reportbug" text="Сообщить о проблеме" />
+   <l:gentext key="editsource" text="Редактировать исходный документ" />
+
+   <l:gentext key="previouspage" text="Назад" />
+   <l:gentext key="nextpage" text="Далее" />
+
+   <l:gentext key="sharethispage" text="Поделиться страницей" />
+   <l:gentext key="shareviafacebook" text="Facebook"/>
+   <l:gentext key="sharevialinkedin" text="LinkedIn"/>
+   <l:gentext key="shareviatwitter" text="Twitter"/>
+   <l:gentext key="shareviaemail" text="Электронная почта"/>
+   <l:gentext key="printthispage" text="Печать страницы" />
+   <l:gentext key="susecareers" text="Вакансии" />
+   <l:gentext key="suselegal" text="Юридическая информация" />
+   <l:gentext key="suseabout" text="О нас" />
+   <l:gentext key="susecontact" text="Свяжитесь с нами" />
+   <l:gentext key="version.info" text="Действительно для " />
+   <l:gentext key="totopofpage" text="Наверх"/>
+
+   <l:gentext key="version" text="Версия" />
+   <l:gentext key="Version" text="Версия" />
+
+   <l:gentext key="step.optional" text="(Необязательно)"/>
+   <l:gentext key="GlossSeeAlso" text="См. также" />
+   <l:gentext key="glossseealso" text="См. также" />
+
 
    <!-- In most cases, this has to be empty -->
    <l:dingbat key="guimenustartquote" text=""/>
    <l:dingbat key="guimenuendquote" text=""/>
 
-   <l:gentext key="selectlanguage" text="Выбор языка"/>
-   <l:gentext key="selectformat" text="Выбор формата"/>
-   <l:gentext key="formathtml" text="Веб-страницы"/>
-   <l:gentext key="formatsinglehtml" text="Отдельная веб-страница"/>
-   <l:gentext key="formatpdf" text="PDF"/>
-   <l:gentext key="formatepub" text="Электронная книга (EPUB)"/>
-   <l:gentext key="contentsoverview" text="Содержание"/>
-   <l:gentext key="showcontentsoverview" text="Показать содержание"/>
-   <l:gentext key="find" text="Найти"/>
-
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
-
-   <l:gentext key="navigation" text="Навигация"/>
-   <l:gentext key="sharethispage" text="Рассказать об этой странице"/>
-   <l:gentext key="shareviafacebook" text="Facebook"/>
-   <l:gentext key="sharevialinkedin" text="LinkedIn"/>
-   <l:gentext key="shareviatwitter" text="Twitter"/>
-   <l:gentext key="shareviaemail" text="Электронная почта"/>
-   <l:gentext key="printthispage" text="Распечатать эту страницу"/>
-   <l:gentext key="susecareers" text="Careers"/>
-   <l:gentext key="suselegal" text="Legal"/>
-   <l:gentext key="suseabout" text="About"/>
-   <l:gentext key="susecontact" text="Contact Us"/>
-   <l:gentext key="version.info" text="Относится к "/>
-   <l:gentext key="totopofpage" text="Наверх"/>
-
-   <l:gentext key="version" text="Ве́рсия"/>
-   <l:gentext key="Version" text="Ве́рсия"/>
-
-   <l:gentext key="step.optional" text="(Необязательно)"/>
-
    <l:context name="bypass-block">
-     <l:template name="bypass-to-content" text="Перейти к началу текста"/>
-     <l:template name="bypass-to-nav" text="Перейти к навигации по странице: предыдущая страница [клавиша доступа p]/следующая страница [клавиша доступа n]"/>
+     <l:template name="bypass-to-content" text="Перейти к содержимому" />
+     <l:template name="bypass-to-nav" text="Навигация по страницам: предыдущая страница [access key p]/следующая страница [access key n]" />
+   </l:context>
+
+   <l:context name="glossary">
+     <l:template name="seealso" text="См. также %t." />
    </l:context>
 
    <l:context name="styles">

--- a/suse2022-ns/common/l10n/zh_cn.xml
+++ b/suse2022-ns/common/l10n/zh_cn.xml
@@ -4,43 +4,112 @@
   english-language-name="Chinese Simplified">
 
   <l:gentext key="LocalisedLanguageName" text="&#20013;&#25991;(&#31616;&#20307;)"/>
-  <l:gentext key="admonseparator"  text="&#65306;"/>
-  <l:gentext key="ListofAuthors" text="&#20316;&#32773;&#21015;&#34920;"/>
-  <l:gentext key="Authors" text="&#20316;&#32773;"/>
-  <l:gentext key="Contributor"     text="贡献者"/>
-  <l:gentext key="Contributors"    text="贡献者"/>
+  <l:gentext key="SeeAlso"         text="另请参见" />
+  <l:gentext key="Authors"         text="作者" />
+  <l:gentext key="TableofContents" text="目录" />
+  <l:gentext key="ListofAuthors"   text="作者列表" />
+  <l:gentext key="Contributor"     text="投稿者" />
+  <l:gentext key="Contributors"    text="投稿者" />
 
-  <l:gentext key="admonseparator"  text="︰ "/>
-  <l:gentext key="selectlanguage" text="选择语言"/>
-  <l:gentext key="selectformat" text="选择格式"/>
-  <l:gentext key="formathtml" text="网页"/>
-  <l:gentext key="formatsinglehtml" text="单一网页"/>
-  <l:gentext key="formatpdf" text="PDF"/>
-  <l:gentext key="formatepub" text="E-book (EPUB)"/> <!-- According to Google Translate, this should be: 电子书（EPUB） -->
-  <l:gentext key="contentsoverview" text="内容"/>
-  <l:gentext key="showcontentsoverview" text="显示内容"/>
-  <l:gentext key="find" text="查找"/>
+  <l:gentext key="admonseparator"  text="：" />
 
-  <l:gentext key="runinhead.default.title.end.punct" text="&#xff1a;"/>
+  <l:gentext key="selectlanguage" text="选择语言" />
+  <l:gentext key="selectformat" text="选择格式" />
+  <l:gentext key="formathtml" text="网页" />
+  <l:gentext key="formatsinglehtml" text="单页网页" />
+  <l:gentext key="formatpdf" text="PDF" />
+  <l:gentext key="formatepub" text="电子书 (EPUB)" />
+  <l:gentext key="contentsoverview" text="目录" />
+  <l:gentext key="showcontentsoverview" text="显示目录" />
+  <l:gentext key="find" text="查找" />
 
-  <l:gentext key="navigation" text="导航"/>
-  <l:gentext key="sharethispage" text="分享此页"/>
-  <l:gentext key="shareviafacebook" text="Facebook"/>
-  <l:gentext key="sharevialinkedin" text="LinkedIn"/>
-  <l:gentext key="shareviatwitter" text="Twitter"/>
-  <l:gentext key="shareviaemail" text="电子邮件"/>
-  <l:gentext key="printthispage" text="打印此页"/>
-  <l:gentext key="susecareers" text="职业"/>
-  <l:gentext key="suselegal" text="法律"/>
-  <l:gentext key="suseabout" text="关于"/>
-  <l:gentext key="susecontact" text="联系我们"/>
-  <l:gentext key="version.info" text="适用于"/>
-  <l:gentext key="totopofpage" text="顶部"/>
+  <l:gentext key="runinhead.default.title.end.punct" text="." />
 
+  <l:gentext key="navigation" text="导航" />
+  <l:gentext key="moredocuments" text="更多文档" />
 
-  <!-- In most cases, this has to be empty -->
-  <l:dingbat key="guimenustartquote" text=""/>
-  <l:dingbat key="guimenuendquote" text=""/>
+  <l:gentext key="onthispage" text="在此页上" />
+
+  <l:gentext key="givefeedback" text="提供反馈" />
+  <l:gentext key="reportbug" text="报告问题" />
+  <l:gentext key="editsource" text="编辑源文档" />
+
+  <l:gentext key="previouspage" text="上一页" />
+  <l:gentext key="nextpage" text="下一页" />
+
+  <l:gentext key="sharethispage" text="分享此页" />
+  <l:gentext key="shareviafacebook" text="Facebook" />
+  <l:gentext key="sharevialinkedin" text="LinkedIn" />
+  <l:gentext key="shareviatwitter" text="Twitter" />
+  <l:gentext key="shareviaemail" text="电子邮件" />
+  <l:gentext key="printthispage" text="打印此页" />
+  <l:gentext key="susecareers" text="招贤纳士" /><l:gentext key="admonseparator"  text="：" />
+
+  <l:gentext key="selectlanguage" text="选择语言" />
+  <l:gentext key="selectformat" text="选择格式" />
+  <l:gentext key="formathtml" text="网页" />
+  <l:gentext key="formatsinglehtml" text="单页网页" />
+  <l:gentext key="formatpdf" text="PDF" />
+  <l:gentext key="formatepub" text="电子书 (EPUB)" />
+  <l:gentext key="contentsoverview" text="目录" />
+  <l:gentext key="showcontentsoverview" text="显示目录" />
+  <l:gentext key="find" text="查找" />
+
+  <l:gentext key="runinhead.default.title.end.punct" text="." />
+
+  <l:gentext key="navigation" text="导航" />
+  <l:gentext key="moredocuments" text="更多文档" />
+
+  <l:gentext key="onthispage" text="在此页上" />
+
+  <l:gentext key="givefeedback" text="提供反馈" />
+  <l:gentext key="reportbug" text="报告问题" />
+  <l:gentext key="editsource" text="编辑源文档" />
+
+  <l:gentext key="previouspage" text="上一页" />
+  <l:gentext key="nextpage" text="下一页" />
+
+  <l:gentext key="sharethispage" text="分享此页" />
+  <l:gentext key="shareviafacebook" text="Facebook" />
+  <l:gentext key="sharevialinkedin" text="LinkedIn" />
+  <l:gentext key="shareviatwitter" text="Twitter" />
+  <l:gentext key="shareviaemail" text="电子邮件" />
+  <l:gentext key="printthispage" text="打印此页" />
+  <l:gentext key="susecareers" text="招贤纳士" />
+  <l:gentext key="suselegal" text="法律" />
+  <l:gentext key="suseabout" text="关于" />
+  <l:gentext key="susecontact" text="联系我们" />
+  <l:gentext key="version.info" text="适用范围 " />
+  <l:gentext key="totopofpage" text="返回页首" />
+
+  <l:gentext key="version" text="版本" />
+  <l:gentext key="Version" text="版本" />
+
+  <l:gentext key="step.optional" text="(可选)" />
+  <l:gentext key="GlossSeeAlso" text="另请参见" />
+  <l:gentext key="glossseealso" text="另请参见" />
+  <l:gentext key="suselegal" text="法律" />
+  <l:gentext key="suseabout" text="关于" />
+  <l:gentext key="susecontact" text="联系我们" />
+  <l:gentext key="version.info" text="适用范围 " />
+  <l:gentext key="totopofpage" text="返回页首" />
+
+  <l:gentext key="version" text="版本" />
+  <l:gentext key="Version" text="版本" />
+  
+  <l:gentext key="step.optional" text="(可选)" />
+  <l:gentext key="GlossSeeAlso" text="另请参见" />
+  <l:gentext key="glossseealso" text="另请参见" />
+
+   <l:context name="bypass-block">
+    <l:template name="bypass-to-content" text="跳到内容" />
+    <l:template name="bypass-to-nav" text="跳到页面导航：上一页 [access key p]/下一页 [access key n]" />
+  </l:context>
+
+  <l:context name="glossary">
+    <l:template name="seealso" text="另请参见 %t。" />
+  </l:context>
+
 
   <!-- Not quite sure why we need this: most of our other l10n files do not
   override the authorgroup context, only the zh_*.xml files do. However, we do
@@ -144,7 +213,6 @@
     <l:template name="November" text="11" lang="zh_cn"/>
     <l:template name="December" text="12" lang="zh_cn"/>
   </l:context>
-
 
   <l:context name="xref">
     <!-- Discussed these translations with Yan Gao:

--- a/suse2022-ns/common/l10n/zh_tw.xml
+++ b/suse2022-ns/common/l10n/zh_tw.xml
@@ -4,58 +4,72 @@
         english-language-name="Chinese (Traditional)">
 
    <l:gentext key="LocalisedLanguageName" text="&#20013;&#25991;(&#32321;&#20307;)"/>
-   <l:gentext key="ListofAuthors" text="&#x539f;&#x8457;&#x8005;&#x540d;&#x55ae;"/>
-   <l:gentext key="Authors" text="&#x539f;&#x8457;"/>
-   <l:gentext key="admonseparator"  text="&#65306;"/>
-   <l:gentext key="Contributor"     text="貢獻者"/>
-   <l:gentext key="Contributors"    text="貢獻者"/>
+  <l:gentext key="SeeAlso"         text="另請參閱" />
+  <l:gentext key="Authors"         text="原著者" />
+  <l:gentext key="TableofContents" text="目錄" />
+  <l:gentext key="ListofAuthors"   text="原著者清單" />
+  <l:gentext key="Contributor"     text="投稿者" />
+  <l:gentext key="Contributors"    text="投稿者" />
 
-   <l:gentext key="TableofContents" text="&#30446;&#37636;"/>
-   <l:gentext key="tableofcontents" text="&#30446;&#37636;"/>
-   <l:gentext key="index symbols" text="&#31526;&#34399;"/>
+  <l:gentext key="admonseparator"  text="：" />
 
-   <l:gentext key="admonseparator"  text="︰ "/>
-
-   <l:dingbat key="guimenustartquote" text=""/>
-   <l:dingbat key="guimenuendquote" text=""/>
-   <l:dingbat key="startquote" text="&#x300c;"/>
-   <l:dingbat key="endquote" text="&#x300d;"/>
-
-   <l:gentext key="selectlanguage" text="選取語言"/>
-   <l:gentext key="selectformat" text="選取格式"/>
-   <l:gentext key="formathtml" text="網頁"/>
-   <l:gentext key="formatsinglehtml" text="單一網頁"/>
-   <l:gentext key="formatpdf" text="PDF"/>
-   <l:gentext key="formatepub" text="E-book (EPUB)"/> <!-- According to Google Translate, this should be: 電子書（EPUB） -->
-   <l:gentext key="contentsoverview" text="內容"/>
-   <l:gentext key="showcontentsoverview" text="顯示內容"/>
-   <l:gentext key="find" text="尋找"/>
-
-   <!-- Submitted upstream with: https://github.com/docbook/xslt10-stylesheets/pull/23 (Jan 2017) -->
-   <gentext key="Procedure" text="程序"/>
-   <gentext key="procedure" text="程序"/>
-   <gentext key="ListofProcedures" text="程序清單"/>
-   <gentext key="listofprocedures" text="程序清單"/>
-   <!-- End of stuff submitted via PR -->
+  <l:gentext key="selectlanguage" text="選取語言" />
+  <l:gentext key="selectformat" text="選取格式" />
+  <l:gentext key="formathtml" text="網頁" />
+  <l:gentext key="formatsinglehtml" text="單頁網頁" />
+  <l:gentext key="formatpdf" text="PDF" />
+  <l:gentext key="formatepub" text="電子書 (EPUB)" />
+  <l:gentext key="contentsoverview" text="目錄" />
+  <l:gentext key="showcontentsoverview" text="顯示目錄" />
+  <l:gentext key="find" text="尋找" />
 
    <l:gentext key="runinhead.default.title.end.punct" text="&#xff1a;"/>
 
    <l:gentext key="navigation" text="導覽"/>
-   <l:gentext key="sharethispage" text="共享此頁面"/>
+   <l:gentext key="moredocuments" text="更多文件" />
+
+   <l:gentext key="onthispage" text="在此頁上" />
+
+   <l:gentext key="givefeedback" text="提供意見" />
+   <l:gentext key="reportbug" text="報告問題" />
+   <l:gentext key="editsource" text="編輯來源文件" />
+
+   <l:gentext key="previouspage" text="上一頁" />
+   <l:gentext key="nextpage" text="下一頁" />
+
+   <l:gentext key="sharethispage" text="分享此頁" />
    <l:gentext key="shareviafacebook" text="Facebook"/>
    <l:gentext key="sharevialinkedin" text="LinkedIn"/>
    <l:gentext key="shareviatwitter" text="Twitter"/>
    <l:gentext key="shareviaemail" text="電子郵件"/>
-   <l:gentext key="printthispage" text="列印此頁面"/>
-   <l:gentext key="susecareers" text="Careers"/>
-   <l:gentext key="suselegal" text="Legal"/>
-   <l:gentext key="suseabout" text="About"/>
-   <l:gentext key="susecontact" text="Contact Us"/>
-   <l:gentext key="version.info" text="套用至"/>
-   <l:gentext key="totopofpage" text="頂端"/>
+   <l:gentext key="printthispage" text="列印此頁" />
+   <l:gentext key="susecareers" text="工作機會" />
+   <l:gentext key="suselegal" text="法律" />
+   <l:gentext key="suseabout" text="關於" />
+   <l:gentext key="susecontact" text="與我們聯絡" />
+   <l:gentext key="version.info" text="適用範圍 " />
+   <l:gentext key="totopofpage" text="返回頁首" />
 
-   <l:gentext key="Part" text=""/>
-   <l:gentext key="part" text=""/>
+   <l:gentext key="version" text="版本" />
+   <l:gentext key="Version" text="版本" />
+
+   <l:gentext key="step.optional" text="(選填)" />
+   <l:gentext key="GlossSeeAlso" text="另請參閱" />
+   <l:gentext key="glossseealso" text="另請參閱" />
+
+
+   <!-- In most cases, this has to be empty -->
+   <l:dingbat key="guimenustartquote" text=""/>
+   <l:dingbat key="guimenuendquote" text=""/>
+
+   <l:context name="bypass-block">
+     <l:template name="bypass-to-content" text="跳至內容" />
+     <l:template name="bypass-to-nav" text="跳至頁面導覽：上一頁 [access key p]/下一頁 [access key n]" />
+   </l:context>
+
+   <l:context name="glossary">
+     <l:template name="seealso" text="另請參閱 %t。" />
+   </l:context>
 
    <!-- Not quite sure why we need this: most of our other l10n files do not
    override the authorgroup context, only the zh_*.xml files do. However, we do


### PR DESCRIPTION
This PR contains missing strings for different languages. Localized strings avoid content to "vanish".