### PR TITLE
Fix#458: correct l10n issue for fr

### DIFF
--- a/suse2022-ns/common/l10n/fr.xml
+++ b/suse2022-ns/common/l10n/fr.xml
@@ -63,7 +63,7 @@
 
       <l:template name="example-label" text="Exemple %nt&#160;:"/>
       <l:template name="example-title" text="%t"/>
-      <l:template name="figure-label" text="Figure %nt&#160;:"/>
+      <l:template name="figure-label" text="Figure %n&#160;:"/>
       <l:template name="figure-title" text="%t"/>
       <l:template name="glosslist-label" text=""/>
       <l:template name="glosslist-title" text="%t"/>


### PR DESCRIPTION
Found during localization of SES 7.1 l

* figure-label for fr-fr: remove stray letter "t"