### PR TITLE
GH Action: Use ubuntu-latest and run update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     #  PATH: .:$PATH
     #  LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so
     #  DBXSL: http://docbook.sourceforge.net/release/xsl/current
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Output env variables
         run: |
@@ -42,9 +42,12 @@ jobs:
           echo "\n"
           echo "::debug::---end"
 
+      - name: Run update
+        run: sudo apt-get update --yes
+
       - name: Install dependencies
         run: |
-          sudo apt-get install -y jing libbatik-java libavalon-framework-java \
+          sudo apt-get install --fix-missing -y jing libbatik-java libavalon-framework-java \
                xml-core libxml2-utils docbook docbook-xsl parallel
 
       - uses: actions/checkout@v2

--- a/tests/ignore-xslt.txt
+++ b/tests/ignore-xslt.txt
@@ -5,3 +5,4 @@ suse2013/fo/logo.xsl
 suse2013/xhtml5/html5-element-mods.xsl
 suse2021-ns/fo/logo.xsl
 suse2021-ns/xhtml5/html5-element-mods.xsl
+suse2022-ns/fo/logo.xsl

--- a/tests/xsltfiles.txt
+++ b/tests/xsltfiles.txt
@@ -11,3 +11,5 @@ opensuse2013/*/*.xsl
 opensuse2013/*.xsl
 suse2021-ns/*/*.xsl
 suse2021-ns/*.xsl
+suse2022-ns/*/*.xsl
+suse2022-ns/*.xsl


### PR DESCRIPTION
* Run update before installation
* Use `--fix-missing` for installing packages. From the manpage:

  > "Ignore missing packages; if packages cannot be retrieved or fail the integrity check after retrieval (corrupted package files), hold back those packages and handle the result."