### PR TITLE
Fix #463: Use correct inline color for screen

### DIFF
--- a/source-assets/styles2022/sass/custom/content-mono-verbatim.sass
+++ b/source-assets/styles2022/sass/custom/content-mono-verbatim.sass
@@ -170,7 +170,7 @@ article
     padding: 0
 
   code
-    color: $c_pine
+    color: inherit // $c_pine
 
   .command
     color: $c_waterhole_30

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -3153,7 +3153,7 @@ article a:hover code {
   padding: 0; }
 
 .verbatim-wrap code {
-  color: #0c322c; }
+  color: inherit; }
 
 .verbatim-wrap .command {
   color: #bfcbfb; }


### PR DESCRIPTION
Some inline elements inside `<screen>` like `<filename>` got hidden as it was rendered with the wrong color.

Using `inherit` instead of `$c_pine` to display it correctly.

---

@tbazant when I apply this CSS stylesheet to your SES Admin guide, I get this result:

<details>
  <summary>Screenshot result with inherit (click me)</summary>

![Screenshot_20220627_114818](https://user-images.githubusercontent.com/1312925/175913735-41ad64d7-4f95-48c3-933e-ede343a24eb2.png)
</details>

Could you confirm?

Just copy the `style.css` file from this branch (file `suse2022-ns/static/css/style.css`) into `build/ses-admin/html/book-storage-admin/static/css/style.css` of your built HTML, reload, and check.

Thanks!
