### PR TITLE
Disable test for old suse folder

### DIFF
--- a/tests/xsltfiles.txt
+++ b/tests/xsltfiles.txt
@@ -1,8 +1,8 @@
 # Stylesheets to validate:
-suse/*/*.xsl
-suse/*.xsl
-suse/flyer/fo/*.xsl
-suse/pocket/fo/*.xsl
+# suse/*/*.xsl
+# suse/*.xsl
+# suse/flyer/fo/*.xsl
+# suse/pocket/fo/*.xsl
 suse2013/*/*.xsl
 suse2013/*.xsl
 daps2013/*/*.xsl


### PR DESCRIPTION
The old `suse/` folder is deprecated; no need to test them (speed up the tests).