### PR TITLE
Fix #458: Add missing datetime format for zh_*

### DIFF
--- a/suse/common/l10n/zh_cn.xml
+++ b/suse/common/l10n/zh_cn.xml
@@ -142,5 +142,6 @@
    
    <l:context name="datetime">
      <l:template name="titlepage.format" text="Y-m-d"/>
+     <l:template name="format" text="Y-m-d"/>
    </l:context>
 </l:l10n>

--- a/suse/common/l10n/zh_tw.xml
+++ b/suse/common/l10n/zh_tw.xml
@@ -180,6 +180,7 @@
    </l:context>
 
    <l:context name="datetime">
-     <l:template name="titlepage.format" text="m/d/Y"/>
+     <l:template name="titlepage.format" text="Y-m-d"/>
+     <l:template name="format" text="Y-m-d"/>
    </l:context>
 </l:l10n>

--- a/suse2013/common/l10n/zh_cn.xml
+++ b/suse2013/common/l10n/zh_cn.xml
@@ -205,5 +205,6 @@
 
   <l:context name="datetime">
     <l:template name="titlepage.format" text="Y-m-d"/>
+    <l:template name="format" text="Y-m-d"/>
   </l:context>
 </l:l10n>

--- a/suse2013/common/l10n/zh_tw.xml
+++ b/suse2013/common/l10n/zh_tw.xml
@@ -256,6 +256,7 @@
    </l:context>
 
    <l:context name="datetime">
-     <l:template name="titlepage.format" text="m/d/Y"/>
+     <l:template name="titlepage.format" text="Y-m-d"/>
+     <l:template name="format" text="Y-m-d"/>
    </l:context>
 </l:l10n>

--- a/suse2021-ns/common/l10n/zh_cn.xml
+++ b/suse2021-ns/common/l10n/zh_cn.xml
@@ -205,5 +205,6 @@
 
   <l:context name="datetime">
     <l:template name="titlepage.format" text="Y-m-d"/>
+    <l:template name="format" text="Y-m-d"/>
   </l:context>
 </l:l10n>

--- a/suse2021-ns/common/l10n/zh_tw.xml
+++ b/suse2021-ns/common/l10n/zh_tw.xml
@@ -256,6 +256,7 @@
    </l:context>
 
    <l:context name="datetime">
-     <l:template name="titlepage.format" text="m/d/Y"/>
+     <l:template name="titlepage.format" text="Y-m-d"/>
+     <l:template name="format" text="Y-m-d"/>
    </l:context>
 </l:l10n>

--- a/suse2022-ns/common/l10n/zh_cn.xml
+++ b/suse2022-ns/common/l10n/zh_cn.xml
@@ -205,5 +205,6 @@
 
   <l:context name="datetime">
     <l:template name="titlepage.format" text="Y-m-d"/>
+    <l:template name="format" text="Y-m-d"/>
   </l:context>
 </l:l10n>

--- a/suse2022-ns/common/l10n/zh_tw.xml
+++ b/suse2022-ns/common/l10n/zh_tw.xml
@@ -256,6 +256,7 @@
    </l:context>
 
    <l:context name="datetime">
-     <l:template name="titlepage.format" text="m/d/Y"/>
+     <l:template name="titlepage.format" text="Y-m-d"/>
+     <l:template name="format" text="Y-m-d"/>
    </l:context>
 </l:l10n>


### PR DESCRIPTION
According to Julia, it's `yyyy-mm-dd`.