### PR TITLE
Make "Report bug" links attached to titles

### DIFF
--- a/source-assets/styles2022/sass/custom/permalink.sass
+++ b/source-assets/styles2022/sass/custom/permalink.sass
@@ -10,7 +10,41 @@
   &:focus
     color: $c_funky_darker_jungle !important
 
+  .report-bug
+    opacity: 0.3
+    font-weight: normal
+    text-decoration: none
+    // Clean the below up in Q3 2013 or so...
+    -webkit-transition: opacity 0.2s ease-in-out 0.1s
+    -moz-transition: opacity 0.2s ease-in-out 0.1s
+    transition: opacity 0.2s ease-in-out 0.1s
+
+
 *:hover,
 *:focus
   > .permalink
     display: inline-block
+
+
+.report-bug
+    color: #333
+    font-size: 10px
+    height: 15px
+    line-height: 15px
+    overflow: hidden
+    padding: 0 3px
+    border-bottom: 1px solid transparent
+    background-color: #EEE
+    text-transform: uppercase
+    display: inline-block
+    float: right
+
+    &:hover,
+    &:focus,
+    &:active
+      color: #439239
+      text-decoration: none !important
+
+
+*:hover > .report-bug
+    opacity: 1

--- a/suse2022-ns/common/url-encode.xsl
+++ b/suse2022-ns/common/url-encode.xsl
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Named template:
+     url-encode(str)
+
+  Purpose:
+    RFC 2396 Uniform Resource Identifiers (URI): Generic Syntax lists
+    the following reserved characters.
+
+    reserved    = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "+" |
+                  "$" | ","
+
+  Parameter:
+     - str: the URL to encode
+  
+  Output:
+     - the encoded URL
+  
+  Example:
+     <xsl:variable name="url">
+        <xsl:call-templates name="url-encode">
+           <xsl:with-param name="str">abc def</xsl:with-param>
+        </xsl:call-templates>
+     </xsl:variable>
+  
+     => url="abc%20def"
+  
+  See also:
+    https://stackoverflow.com/a/3518109
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  ISO-8859-1 based URL-encoding demo
+  Written by Mike J. Brown, mike@skew.org.
+  Updated 2015-10-24 (to update the license).
+
+  License: CC0 <https://creativecommons.org/publicdomain/zero/1.0/deed.en>
+
+  Also see http://skew.org/xml/misc/URI-i18n/ for a discussion of
+  non-ASCII characters in URIs.
+
+
+-->
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+
+<xsl:variable name="ascii"> !"#$%&amp;'()*+,-./0123456789:;&lt;=&gt;?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~</xsl:variable>
+  <xsl:variable name="latin1"
+>&#160;&#161;&#162;&#163;&#164;&#165;&#166;&#167;&#168;&#169;&#170;&#171;&#172;&#173;&#174;&#175;&#176;&#177;&#178;&#179;&#180;&#181;&#182;&#183;&#184;&#185;&#186;&#187;&#188;&#189;&#190;&#191;&#192;&#193;&#194;&#195;&#196;&#197;&#198;&#199;&#200;&#201;&#202;&#203;&#204;&#205;&#206;&#207;&#208;&#209;&#210;&#211;&#212;&#213;&#214;&#215;&#216;&#217;&#218;&#219;&#220;&#221;&#222;&#223;&#224;&#225;&#226;&#227;&#228;&#229;&#230;&#231;&#232;&#233;&#234;&#235;&#236;&#237;&#238;&#239;&#240;&#241;&#242;&#243;&#244;&#245;&#246;&#247;&#248;&#249;&#250;&#251;&#252;&#253;&#254;&#255;</xsl:variable>
+
+  <!-- Characters that usually don't need to be escaped -->
+  <xsl:variable name="safe">!'()*-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~</xsl:variable>
+
+  <xsl:variable name="hex" >0123456789ABCDEF</xsl:variable>
+
+<xsl:template name="url-encode">
+    <xsl:param name="str"/>   
+    <xsl:if test="$str">
+      <xsl:variable name="first-char" select="substring($str,1,1)"/>
+      <xsl:choose>
+        <xsl:when test="contains($safe,$first-char)">
+          <xsl:value-of select="$first-char"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:variable name="codepoint">
+            <xsl:choose>
+              <xsl:when test="contains($ascii,$first-char)">
+                <xsl:value-of select="string-length(substring-before($ascii,$first-char)) + 32"/>
+              </xsl:when>
+              <xsl:when test="contains($latin1,$first-char)">
+                <xsl:value-of select="string-length(substring-before($latin1,$first-char)) + 160"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:message terminate="no">Warning: string contains a character that is out of range! Substituting "?".</xsl:message>
+                <xsl:text>63</xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
+        <xsl:variable name="hex-digit1" select="substring($hex,floor($codepoint div 16) + 1,1)"/>
+        <xsl:variable name="hex-digit2" select="substring($hex,$codepoint mod 16 + 1,1)"/>
+        <xsl:value-of select="concat('%',$hex-digit1,$hex-digit2)"/>
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:if test="string-length($str) &gt; 1">
+        <xsl:call-template name="url-encode">
+          <xsl:with-param name="str" select="substring($str,2)"/>
+        </xsl:call-template>
+      </xsl:if>
+    </xsl:if>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -3290,10 +3290,36 @@ article a:hover code {
   text-decoration: none !important; }
   .permalink:hover, .permalink:focus {
     color: #26915e !important; }
+  .permalink .report-bug {
+    opacity: 0.3;
+    font-weight: normal;
+    text-decoration: none;
+    -webkit-transition: opacity 0.2s ease-in-out 0.1s;
+    -moz-transition: opacity 0.2s ease-in-out 0.1s;
+    transition: opacity 0.2s ease-in-out 0.1s; }
 
 *:hover > .permalink,
 *:focus > .permalink {
   display: inline-block; }
+
+.report-bug {
+  color: #333;
+  font-size: 10px;
+  height: 15px;
+  line-height: 15px;
+  overflow: hidden;
+  padding: 0 3px;
+  border-bottom: 1px solid transparent;
+  background-color: #EEE;
+  text-transform: uppercase;
+  display: inline-block;
+  float: right; }
+  .report-bug:hover, .report-bug:focus, .report-bug:active {
+    color: #439239;
+    text-decoration: none !important; }
+
+*:hover > .report-bug {
+  opacity: 1; }
 
 @page {
   size: portrait;

--- a/suse2022-ns/static/js/script.js
+++ b/suse2022-ns/static/js/script.js
@@ -130,7 +130,7 @@ function githubUrl(sectionName, permalink) {
     url += "&amp;labels=" + encodeURIComponent(ghLabels);
   }
   return url;
-}
+};
 
 
 function bugzillaUrl(sectionName, permalink) {
@@ -153,7 +153,7 @@ function bugzillaUrl(sectionName, permalink) {
     url += "&amp;version=" + encodeURIComponent(bscVersion);
   }
   return url;
-}
+};
 
 
 // update the report bug url for the current section id as the user is scrolling
@@ -233,7 +233,7 @@ function addClipboardButtons() {
       return true;
     }
   );
-}
+};
 
 function copyToClipboard(elm) {
   // use temporary hidden form element for selection and copy action
@@ -282,7 +282,7 @@ function copyToClipboard(elm) {
   }
 
   return succeed;
-}
+};
 
 
 function hashActivator() {
@@ -295,7 +295,7 @@ function hashActivator() {
       location.hash = $( locationhash ).parent(".qandaentry").prev('.free-id').attr('id');
     };
   };
-}
+};
 
 
 // INIT!
@@ -418,7 +418,9 @@ $(function() {
         }, false);
  });
 
-  bugReportScrollSpy();
+ //  bugReportScrollSpy();
+  console.log("Calling addBugLinks...")
+  addBugLinks();
 
   // hljs likes to unset click handlers, so run after it
   // FIXME: this interval thing is a little crude
@@ -430,3 +432,40 @@ $(function() {
   }, 500);
 
 });
+
+function addBugLinks() {
+  // do not create links if there is no URL
+  if ( typeof(bugtrackerUrl) == 'string') {
+    $('.permalink:not([href^=#idm])').each(function () {
+      var permalink = this.href;
+      var sectionNumber = "";
+      var sectionName = "";
+      var url = "";
+      console.log("this:", this.text,
+                  $(this).prevAll('span.title-number')[0].innerHTML,
+                  $(this).prevAll('span.title-name')[0].innerHTML
+                  );
+      if ( $(this).prevAll('span.title-number')[0] ) {
+        sectionNumber = $(this).prevAll('span.title-number')[0].innerHTML;
+      }
+      if ( $(this).prevAll('span.title-number')[0] ) {
+        sectionName = $(this).prevAll('span.title-name')[0].innerHTML;
+      }
+
+      if (bugtrackerType == 'bsc') {
+        url = bugzillaUrl(sectionName, permalink);
+      }
+      else {
+        url = githubUrl(sectionName, permalink);
+      }
+
+      $(this).before("<a class=\"report-bug\" target=\"_blank\" href=\""
+        + url
+        + "\" title=\"Report a bug against this section of the documentation\">Report Documentation Bug</a> ");
+      return true;
+    });
+  }
+  else {
+    return false;
+  }
+}

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -567,13 +567,8 @@
       <xsl:variable name="valid-for-editurl">
         <xsl:if test="($draft.mode = 'yes' or $show.edit.link = 1) and $editurl != '' and $xmlbase != ''">1</xsl:if>
       </xsl:variable>
-      <xsl:variable name="valid-for-reportbug">
-        <xsl:call-template name="create.bugtracker.information">
-          <xsl:with-param name="evaluate-only" select="1"/>
-        </xsl:call-template>
-      </xsl:variable>
 
-      <xsl:if test="$valid-for-editurl = 1 or $valid-for-reportbug = 1 or $force.generate.give.feedback = 1">
+      <xsl:if test="$valid-for-editurl = 1 or $force.generate.give.feedback = 1">
         <div class="side-title">
           <xsl:call-template name="gentext">
             <xsl:with-param name="key" select="'givefeedback'"/>
@@ -586,15 +581,7 @@
               <xsl:text> </xsl:text>
             </li>
           </xsl:if>
-          <xsl:if test="$valid-for-reportbug = 1">
-            <li>
-              <a id="_feedback-reportbug" href="#" rel="nofollow" target="_blank">
-                <xsl:call-template name="gentext">
-                  <xsl:with-param name="key" select="'reportbug'"/>
-                </xsl:call-template>
-              </a>
-            </li>
-          </xsl:if>
+          <!-- add here a "global" report bug -->
           <xsl:if test="$valid-for-editurl = 1">
             <li>
               <a id="_feedback-editurl" href="{$editurl}{$xmlbase}" rel="nofollow" target="_blank">

--- a/suse2022-ns/xhtml/sections.xsl
+++ b/suse2022-ns/xhtml/sections.xsl
@@ -13,7 +13,7 @@
   xmlns:exsl="http://exslt.org/common"
   xmlns="http://www.w3.org/1999/xhtml"
   xmlns:dm="urn:x-suse:ns:docmanager"
-  exclude-result-prefixes="exsl d">
+  exclude-result-prefixes="exsl dm">
 
   <xsl:template name="create.header.title">
     <xsl:param name="node" select="."/>


### PR DESCRIPTION
Remove the global "Report bug" link from the "Give feedback" label (right column) and add/reintegrate
the former behavior. The JavaScript uses now a opaque "Report documentation bug" link on each title.

Reason: new behavior wasn't reliable and created wrong content.