### PR TITLE
reduce length count for socialmedia and search description to 150

### DIFF
--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -425,10 +425,10 @@ task before
   <!-- <meta> description tags used for search results pages, roughly as
   recommended by the Contentking -->
   <xsl:param name="search.title.length" select="55"/>
-  <xsl:param name="search.description.length" select="160"/>
+  <xsl:param name="search.description.length" select="150"/>
   <!-- Open Graph (og:)/Twitter Cards tags used for social-media preview -->
   <xsl:param name="socialmedia.title.length" select="55"/>
-  <xsl:param name="socialmedia.description.length" select="160"/>
+  <xsl:param name="socialmedia.description.length" select="150"/>
   <!-- Type of content to display in og:type tag, https://ogp.me/#types -->
   <xsl:param name="opengraph.type" select="'article'"/>
   <!-- How Twitter Cards should be displayed, as "summary" (uses smaller square


### PR DESCRIPTION
ContentKing expects description lengths of max. 151 characters. Hoping to reduce the number of rejected meta descriptions and social media descriptions by setting the counter to a max of 150 chars.