### PR TITLE
Minor things around qanda for both PDF and HTML #360

### DIFF
--- a/suse2022-ns/fo/param.xsl
+++ b/suse2022-ns/fo/param.xsl
@@ -104,7 +104,7 @@ set       toc,title
 
 <!-- 14. QAndASet =============================================== -->
 <xsl:param name="qanda.inherit.numeration" select="0"/>
-<xsl:param name="qanda.defaultlabel">qnumber</xsl:param>
+<xsl:param name="qanda.defaultlabel">number</xsl:param>
 
 <!-- 15. Bibliography =========================================== -->
 

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -176,7 +176,7 @@ set       toc,title
 
 <!-- 12. QAndASet =============================================== -->
 <xsl:param name="qanda.inherit.numeration" select="0"/>
-<xsl:param name="qanda.defaultlabel">qnumber</xsl:param>
+<xsl:param name="qanda.defaultlabel">number</xsl:param>
 
 <!-- 13. Linking ================================================ -->
 <xsl:param name="ulink.target">_blank</xsl:param>


### PR DESCRIPTION
* param.xsl contained qnumber for the defaultlabel of qandasets. This seems to be wrong.