### PR TITLE
Fix single h1 issue in HTML

### DIFF
--- a/suse2022-ns/xhtml/component.xsl
+++ b/suse2022-ns/xhtml/component.xsl
@@ -33,6 +33,7 @@
       <xsl:when test="ancestor::d:section">
         <xsl:value-of select="count(ancestor::d:section)+1"/>
       </xsl:when>
+      <xsl:when test="ancestor::d:chapter">0</xsl:when>
       <xsl:when test="ancestor::d:sect5">6</xsl:when>
       <xsl:when test="ancestor::d:sect4">5</xsl:when>
       <xsl:when test="ancestor::d:sect3">4</xsl:when>


### PR DESCRIPTION
Make to cause chapter titles to use a single `<h1>` element in HTML output.

Suggested by Frank and taken from: https://lists.oasis-open.org/archives/docbook-apps/200702/msg00101.html

Current issue: only works ATM for chunked HTML, not single HTML.