### PR TITLE
Fix #493: Use new jQuery syntax (report bug links)

### DIFF
--- a/suse2022-ns/static/js/script.js
+++ b/suse2022-ns/static/js/script.js
@@ -419,7 +419,7 @@ $(function() {
  });
 
  //  bugReportScrollSpy();
-  console.log("Calling addBugLinks...")
+
   addBugLinks();
 
   // hljs likes to unset click handlers, so run after it
@@ -436,7 +436,7 @@ $(function() {
 function addBugLinks() {
   // do not create links if there is no URL
   if ( typeof(bugtrackerUrl) == 'string') {
-    $('.permalink:not([href^=#idm])').each(function () {
+    $('.permalink:not([href^=\\#idm])').each(function () {
       var permalink = this.href;
       var sectionNumber = "";
       var sectionName = "";


### PR DESCRIPTION
New jQuery update needs to quote the `#` inside `[href^=#idm]`.