### PR TITLE
Fix masking error due to new jQuery

### DIFF
--- a/suse2013/static/js/script.js
+++ b/suse2013/static/js/script.js
@@ -40,7 +40,7 @@ $(function() {
   /* http://css-tricks.com/snippets/jquery/smooth-scrolling/ */
   var speed = 400;
 
-  $('a.top-button[href=#]').click(function() {
+  $('a.top-button[href=\\#]').click(function() {
     $('html,body').animate({ scrollTop: 0 }, speed,
       function() { location = location.pathname + '#'; });
     return false;

--- a/suse2013/static/js/script.js
+++ b/suse2013/static/js/script.js
@@ -138,16 +138,27 @@ $(function() {
 function addBugLinks() {
   // do not create links if there is no URL
   if ( typeof(bugtrackerUrl) == 'string') {
-    $('.permalink:not([href^=#idm])').each(function () {
+    $('.permalink:not([href^=\\#idm])').each(function () {
       var permalink = this.href;
       var sectionNumber = "";
       var sectionName = "";
       var url = "";
-      if ( $(this).prevAll('span.number')[0] ) {
-        sectionNumber = $(this).prevAll('span.number')[0].innerHTML;
+      function prev(x) { return $(this).prevAll(x)[0]; };
+
+      if (prev('span.title-number') != undefined) {
+        // Some quickstarts return an undefined object and make the script to fail
+        // this if-clause takes care of this case.
+        console.log("this:", this.text,
+                  prev('span.title-number').innerHTML,
+                  prev('span.title-name').innerHTML
+                   );
       }
-      if ( $(this).prevAll('span.number')[0] ) {
-        sectionName = $(this).prevAll('span.name')[0].innerHTML;
+
+      if ( prev('span.number') ) {
+        sectionNumber = prev('span.number').innerHTML;
+      }
+      if ( prev('span.number') ) {
+        sectionName = prev('span.name').innerHTML;
       }
 
       if (bugtrackerType == 'bsc') {

--- a/suse2021-ns/static/js/script.js
+++ b/suse2021-ns/static/js/script.js
@@ -40,7 +40,7 @@ $(function() {
   /* http://css-tricks.com/snippets/jquery/smooth-scrolling/ */
   var speed = 400;
 
-  $('a.top-button[href=#]').click(function() {
+  $('a.top-button[href=\\#]').click(function() {
     $('html,body').animate({ scrollTop: 0 }, speed,
       function() { location = location.pathname + '#'; });
     return false;

--- a/suse2021-ns/static/js/script.js
+++ b/suse2021-ns/static/js/script.js
@@ -138,16 +138,27 @@ $(function() {
 function addBugLinks() {
   // do not create links if there is no URL
   if ( typeof(bugtrackerUrl) == 'string') {
-    $('.permalink:not([href^=#idm])').each(function () {
+    $('.permalink:not([href^=\\#idm])').each(function () {
       var permalink = this.href;
       var sectionNumber = "";
       var sectionName = "";
       var url = "";
-      if ( $(this).prevAll('span.number')[0] ) {
-        sectionNumber = $(this).prevAll('span.number')[0].innerHTML;
+      function prev(x) { return $(this).prevAll(x)[0]; };
+
+      if (prev('span.title-number') != undefined) {
+        // Some quickstarts return an undefined object and make the script to fail
+        // this if-clause takes care of this case.
+        console.log("this:", this.text,
+                  prev('span.title-number').innerHTML,
+                  prev('span.title-name').innerHTML
+                   );
       }
-      if ( $(this).prevAll('span.number')[0] ) {
-        sectionName = $(this).prevAll('span.name')[0].innerHTML;
+
+      if ( prev('span.number') ) {
+        sectionNumber = prev('span.number').innerHTML;
+      }
+      if ( prev('span.number') ) {
+        sectionName = prev('span.name').innerHTML;
       }
 
       if (bugtrackerType == 'bsc') {


### PR DESCRIPTION
Related to #493 (report bug links) due to the new jQuery syntax. The new syntax needs to mask a `#` inside the expression `[href=#]`. 

Fixes the old suse2021-ns and suse2013 stylesheets.




