### PR TITLE
Fix #499: Change format of <title>

### DIFF
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -163,14 +163,16 @@
   </xsl:param>
 
   <xsl:param name="title">
-    <xsl:if test="$substructure.title.short != ''">
-      <xsl:value-of select="concat($substructure.title.short, $head.content.title.separator)"/>
+    <xsl:if test="$product-short != ''">
+      <xsl:value-of select="concat($product-short,
+                                   $head.content.title.separator)"/>
     </xsl:if>
 
     <xsl:value-of select="$structure.title"/>
 
-    <xsl:if test="$product != ''">
-      <xsl:value-of select="concat($head.content.title.separator, $product)"/>
+    <xsl:if test="$substructure.title.short != ''">
+      <xsl:value-of select="concat($head.content.title.separator,
+                                   $substructure.title.short)"/>
     </xsl:if>
   </xsl:param>
 
@@ -387,7 +389,7 @@
     <xsl:choose>
       <xsl:when test="string-length(normalize-space($input)) &gt; $ellipsize.after">
         <xsl:value-of select="substring(normalize-space($input),1,$ellipsize.after - 1)"/>
-        <xsl:value-of select="'…'"/>
+        <xsl:text>…</xsl:text>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="normalize-space($input)"/>

--- a/suse2022-ns/xhtml/titlepage.templates.xsl
+++ b/suse2022-ns/xhtml/titlepage.templates.xsl
@@ -27,20 +27,19 @@
     productnumber below. -->
     <xsl:param name="prefer-abbreviation" select="0"/>
 
-    <!-- FIXME: This choose is a little wonky around inheritance and
-    abbreviation preference. May need a bit more think. -->
+    <!--
+      First we search for all productname[@role='abbrev'], starting in the nearest node followed
+      by its ancestors.
+    -->
     <xsl:choose>
       <xsl:when test="*/d:productname[@role='abbrev'] and $prefer-abbreviation = 1">
         <xsl:apply-templates select="(*/d:productname[@role='abbrev'])[last()]"/>
       </xsl:when>
-      <xsl:when test="*/d:productname[not(@role='abbrev')]">
-        <xsl:apply-templates select="(*/d:productname[not(@role='abbrev')])[last()]"/>
-      </xsl:when>
-      <xsl:when test="*/d:productname">
-        <xsl:apply-templates select="(*/d:productname)[last()]"/>
-      </xsl:when>
       <xsl:when test="ancestor-or-self::*/*/d:productname[@role='abbrev'] and $prefer-abbreviation = 1">
         <xsl:apply-templates select="(ancestor-or-self::*/*/d:productname[@role='abbrev'])[last()]"/>
+      </xsl:when>
+      <xsl:when test="*/d:productname[not(@role='abbrev')]">
+        <xsl:apply-templates select="(*/d:productname[not(@role='abbrev')])[last()]"/>
       </xsl:when>
       <xsl:when test="ancestor-or-self::*/*/d:productname[not(@role='abbrev')]">
         <xsl:apply-templates select="(ancestor-or-self::*/*/d:productname[not(@role='abbrev')])[last()]"/>


### PR DESCRIPTION
~For SEO reasons, the length of the <title> tag should be limited to 60 characters. For background info, see https://www.contentkingapp.com/academy/title-tag/#good-length  The title length can be delimited with the parameter `$seo.title.length`.~

The format of the title has been changed. This was the old format:

    <CURRENT_TITLE> | <GUIDE_TITLE> | <PRODUCT> <VERSION>

As <PRODUCT> can be quite long (for example, "SUSE Linux Enterprise Server..."), we use the abbreviated product name. This is taken from `d:productname[@role="abbrev"]`. The new format looks like this:

    <PRODUCT_ABBREV> <VERSION>: <CURRENT_TITLE> | <GUIDE_TITLE>

(We don't shorten the title to make sure we can distinguish the page)
See also DOCTEAM-781