### PR TITLE
Fix #505: Add CJK fonts NotoSans

### DIFF
--- a/suse2022-ns/common/l10n/zh_cn.xml
+++ b/suse2022-ns/common/l10n/zh_cn.xml
@@ -88,18 +88,11 @@
   <l:gentext key="step.optional" text="(可选)" />
   <l:gentext key="GlossSeeAlso" text="另请参见" />
   <l:gentext key="glossseealso" text="另请参见" />
-  <l:gentext key="suselegal" text="法律" />
-  <l:gentext key="suseabout" text="关于" />
-  <l:gentext key="susecontact" text="联系我们" />
-  <l:gentext key="version.info" text="适用范围 " />
-  <l:gentext key="totopofpage" text="返回页首" />
 
-  <l:gentext key="version" text="版本" />
-  <l:gentext key="Version" text="版本" />
-  
-  <l:gentext key="step.optional" text="(可选)" />
-  <l:gentext key="GlossSeeAlso" text="另请参见" />
-  <l:gentext key="glossseealso" text="另请参见" />
+  <l:dingbat key="guimenustartquote" text=""/>
+  <l:dingbat key="guimenuendquote" text=""/>
+  <l:dingbat key="startquote" text="&#x300c;"/>
+  <l:dingbat key="endquote" text="&#x300d;"/>
 
    <l:context name="bypass-block">
     <l:template name="bypass-to-content" text="跳到内容" />

--- a/suse2022-ns/fo/l10n.properties.xml
+++ b/suse2022-ns/fo/l10n.properties.xml
@@ -181,15 +181,15 @@
          + the Western font is usually awkwardly sized
          + the Western font usually does not fit the line weight of the CJK font
     -->
-    <prop name="serif">IPAPMincho, serif</prop>
-    <prop name="sans">IPAPGothic, sans-serif</prop>
-    <prop name="mono">'WenQuanYi Micro Hei Mono', WenQuanYiMicroHeiMono, monospace</prop>
+    <prop name="serif" ref-name="sans"/>
+    <prop name="sans">NotoSansJP, sans-serif</prop>
+    <prop name="mono">NotoSansJP, monospace</prop>
     <!-- We could theoretically enable this for Japanese, but the
          existing bold version of IPA P Mincho is a machine-emboldened mess
          of black ink with bad meta data that leads to it not being
          recognized as the bold version of its original. IPA P Mincho
          does not have a bold version (apparently very unusual). -->
-    <prop name="enable-bold">false</prop>
+    <prop name="enable-bold">true</prop>
     <prop name="enable-serif-semibold">false</prop>
     <prop name="enable-sans-semibold">false</prop>
     <prop name="enable-mono-semibold">false</prop>
@@ -206,9 +206,9 @@
     <prop name="writing-mode" ref-lang="default"/>
   </lang>
   <lang code="ko">
-    <prop name="serif">UnBatang, serif</prop>
-    <prop name="sans">UnDotum, sans-serif</prop>
-    <prop name="mono">'WenQuanYi Micro Hei Mono', WenQuanYiMicroHeiMono, monospace</prop>
+    <prop name="serif" ref-name="sans"/>
+    <prop name="sans">NotoSansKO, sans-serif</prop>
+    <prop name="mono">monospace</prop>
     <prop name="enable-bold">true</prop>
     <prop name="enable-serif-semibold">false</prop>
     <prop name="enable-sans-semibold">false</prop>
@@ -230,10 +230,10 @@
     <!-- Simplified Chinese is most often printed as sans-serif, so use
          that. -->
     <prop name="serif" ref-name="sans"/>
-    <prop name="sans">'WenQuanYi Micro Hei', WenQuanYiMicroHei, sans-serif</prop>
-    <prop name="mono">'WenQuanYi Micro Hei Mono', WenQuanYiMicroHeiMono, monospace</prop>
+    <prop name="sans">NotoSansZH_CN, sans-serif</prop>
+    <prop name="mono">NotoSansZH_CN, monospace</prop>
     <!-- We could enable this with some font support. -->
-    <prop name="enable-bold">false</prop>
+    <prop name="enable-bold">true</prop>
     <prop name="enable-serif-semibold">false</prop>
     <prop name="enable-sans-semibold">false</prop>
     <prop name="enable-mono-semibold">false</prop>
@@ -265,12 +265,12 @@
          + the Western font is usually awkwardly sized
          + the Western font usually does not fit the line weight of the CJK font
     -->
-    <prop name="serif">'AR PL UMing TW', ARPLUMingTW, serif</prop>
-    <prop name="sans" ref-name="serif"/>
-    <prop name="mono">'WenQuanYi Micro Hei Mono', WenQuanYiMicroHeiMono, monospace</prop>
+    <prop name="serif" ref-name="sans"/>
+    <prop name="sans">NotoSansZH_TW, sans-serif</prop>
+    <prop name="mono">NotoSansZH_TW, monospace</prop>
     <!-- We will probably never enable this - that text would just
          become messy blotches of ink. -->
-    <prop name="enable-bold">false</prop>
+    <prop name="enable-bold">true</prop>
     <prop name="enable-serif-semibold">false</prop>
     <prop name="enable-sans-semibold">false</prop>
     <prop name="enable-mono-semibold">false</prop>


### PR DESCRIPTION
* Remove obsolete CJK fonts

Use Google Noto Sans fonts

* Japanese: google-noto-sans-jp-regular-fonts / google-noto-sans-jp-bold-fonts
* Korean: google-noto-sans-kr-regular-fonts / google-noto-sans-kr-bold-fonts
* Simplified Chinese: google-noto-sans-sc-regular-fonts / google-noto-sans-sc-bold-fonts
* Traditional Chinese: google-noto-sans-tc-regular-fonts / google-noto-sans-tc-bold-fonts

TODOs:

* [x] check PDFs of CJK
* [x] check if all fonts are embedded
* [x] check if regular and bold are distinguishable
* [x] Add new fonts in spec file, remove old fonts