### PR TITLE
Create SBP stylesheets structure

### DIFF
--- a/sbp/fo/article.titlepage.templates.xsl
+++ b/sbp/fo/article.titlepage.templates.xsl
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+-->
+
+<!DOCTYPE xsl:stylesheet
+[
+  <!ENTITY % fonts SYSTEM "fonts.ent">
+  <!ENTITY % colors SYSTEM "colors.ent">
+  <!ENTITY % metrics SYSTEM "metrics.ent">
+  %fonts;
+  %colors;
+  %metrics;
+]>
+
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:fo="http://www.w3.org/1999/XSL/Format">
+
+
+  <!-- Recto page -->
+  <xsl:template name="article.titlepage.recto">
+    <fo:table>
+      <fo:table-body>
+        <fo:table-cell text-align="start">
+          <fo:block>
+            <fo:instream-foreign-object
+              content-width="{$titlepage.logo.width.article}"
+              width="{$titlepage.logo.width}">
+              <xsl:call-template name="logo-image" />
+            </fo:instream-foreign-object>
+          </fo:block>
+        </fo:table-cell>
+        <fo:table-cell text-align="right" color="&c_jungle;">
+          <fo:block font-size="&xxx-large;pt">
+            <xsl:apply-templates select="d:info/d:meta[@name='series'][1]" mode="article.titlepage.recto.auto.mode"/>
+          </fo:block>
+          <fo:block font-size="&large;pt">
+            <xsl:apply-templates select="d:info/d:meta[@name='category'][1]" mode="article.titlepage.recto.auto.mode"/>
+          </fo:block>
+        </fo:table-cell>
+      </fo:table-body>
+    </fo:table>
+    <!-- Title -->
+    <fo:block space-before="3cm">
+      <xsl:choose>
+        <xsl:when test="d:artheader/d:title">
+          <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+            select="d:artheader/d:title" />
+        </xsl:when>
+        <xsl:when test="d:info/d:title">
+          <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+            select="d:info/d:title" />
+        </xsl:when>
+        <xsl:when test="d:title">
+          <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+            select="d:title" />
+        </xsl:when>
+      </xsl:choose>
+    </fo:block>
+    <!-- Subtitle -->
+    <fo:block space-before="0.75em">
+      <xsl:choose>
+        <xsl:when test="d:artheader/d:subtitle">
+          <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+            select="d:artheader/d:subtitle" />
+        </xsl:when>
+        <xsl:when test="d:info/d:subtitle">
+          <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+            select="d:info/d:subtitle" />
+        </xsl:when>
+        <xsl:when test="d:subtitle">
+          <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+            select="d:subtitle" />
+        </xsl:when>
+      </xsl:choose>
+    </fo:block>
+
+    <!-- Tools -->
+    <fo:block>
+      <fo:external-graphic content-width="100%"
+        src="{$styleroot}/images/sbp-tools-title.svg" />
+    </fo:block>
+
+    <!-- Platform specific -->
+    <fo:block space-before="2em" text-align="right" font-size="&normal;pt">
+      <xsl:apply-templates select="d:info/d:meta[@name='platform']" mode="article.titlepage.recto.auto.mode"/>
+    </fo:block>
+
+    <!-- Authors -->
+    <fo:block space-before="4em" font-size="&normal;pt">
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+        select="d:articleinfo/d:corpauthor" />
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+        select="d:info/d:corpauthor" />
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+        select="d:articleinfo/d:authorgroup" />
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+        select="d:info/d:authorgroup" />
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+        select="d:articleinfo/d:author" />
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+        select="d:info/d:author" />
+    </fo:block>
+
+    <fo:block-container absolute-position="absolute" top="{$page.height.portrait} * 0.78">
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+      select="d:info/d:cover[d:mediaobject]" />
+    </fo:block-container>
+  </xsl:template>
+
+  <xsl:template name="article.titlepage.separator">
+    <fo:block break-after="page"/>
+  </xsl:template>
+
+  <xsl:template match="d:meta">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="d:meta[@name='series']" mode="article.titlepage.recto.auto.mode">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="d:meta[@name='category']" mode="article.titlepage.recto.auto.mode">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="d:meta[@name='platform']" mode="article.titlepage.recto.auto.mode">
+    <fo:block>
+      <xsl:apply-templates/>
+    </fo:block>
+  </xsl:template>
+
+  <xsl:template match="d:cover[d:mediaobject]" mode="article.titlepage.recto.auto.mode">
+    <xsl:variable name="n" select="count(d:mediaobject)"/>
+    <xsl:if test="count(d:mediaobject) > 5">
+      <!-- We only allow max 5 icons -->
+      <xsl:message terminate="yes">ERROR: There are more than 5 icons on the cover page.</xsl:message>
+    </xsl:if>
+
+    <fo:table role="cover">
+      <fo:table-body>
+        <!-- Cell no. 1 -->
+        <fo:table-cell>
+          <fo:block>
+            <xsl:apply-templates select="d:mediaobject[last() -4]" mode="article.titlepage.recto.auto.mode"/>
+          </fo:block>
+        </fo:table-cell>
+        <!-- Cell no. 2 -->
+        <fo:table-cell>
+          <fo:block><xsl:apply-templates select="d:mediaobject[last() -3]" mode="article.titlepage.recto.auto.mode"/></fo:block>
+        </fo:table-cell>
+        <!-- Cell no. 3 -->
+        <fo:table-cell>
+          <fo:block><xsl:apply-templates select="d:mediaobject[last() -2]" mode="article.titlepage.recto.auto.mode"/></fo:block>
+        </fo:table-cell>
+        <!-- Cell no. 4 -->
+        <fo:table-cell>
+          <fo:block><xsl:apply-templates select="d:mediaobject[last() -1]" mode="article.titlepage.recto.auto.mode"/></fo:block>
+        </fo:table-cell>
+        <!-- Cell no. 5 -->
+        <fo:table-cell>
+          <fo:block><xsl:apply-templates select="d:mediaobject[last()]" mode="article.titlepage.recto.auto.mode"/></fo:block>
+        </fo:table-cell>
+      </fo:table-body>
+    </fo:table>
+  </xsl:template>
+
+  <xsl:template match="d:cover/d:mediaobject" mode="article.titlepage.recto.auto.mode">
+    <xsl:param name="pos"/>
+      <fo:block>
+        <xsl:apply-templates select="."/>
+      </fo:block>
+  </xsl:template>
+
+
+  <xsl:template match="d:title" mode="article.titlepage.recto.auto.mode">
+    <fo:block font-size="{&super-large; * $sans-fontsize-adjust}pt" line-height="{$base-lineheight * 0.85}em"
+      xsl:use-attribute-sets="article.titlepage.recto.style sans.bold.noreplacement"
+      keep-with-next.within-column="always" space-after="{&gutterfragment;}mm">
+      <xsl:apply-templates select="." mode="article.titlepage.recto.mode"/>
+    </fo:block>
+  </xsl:template>
+
+
+  <xsl:template match="d:authorgroup" mode="article.titlepage.recto.auto.mode">
+    <fo:block text-align="outside">
+      <xsl:for-each select="d:author">
+        <fo:block>
+          <xsl:apply-templates select="."
+            mode="article.titlepage.recto.auto.mode">
+            <xsl:with-param name="withlabel" select="0" />
+          </xsl:apply-templates>
+        </fo:block>
+        </xsl:for-each>
+
+      <xsl:for-each select="d:editor|d:othercredit">
+        <fo:block>
+          <xsl:apply-templates select="."
+            mode="article.titlepage.recto.auto.mode">
+            <xsl:with-param name="withlabel" select="0" />
+          </xsl:apply-templates>
+        </fo:block>
+      </xsl:for-each>
+
+    </fo:block>
+  </xsl:template>
+
+
+  <xsl:template match="d:author[d:personname]|d:editor[d:personname]|d:othercredit[d:personname]"
+    mode="article.titlepage.recto.auto.mode">
+    <xsl:call-template name="person.name">
+      <xsl:with-param name="node" select="." />
+    </xsl:call-template>
+    <xsl:if test="d:affiliation">
+      <xsl:text>, </xsl:text>
+      <xsl:apply-templates select="d:affiliation/d:jobtitle"
+        mode="article.titlepage.recto.auto.mode" />
+      <xsl:apply-templates select="d:affiliation/d:orgname"
+        mode="article.titlepage.recto.auto.mode" />
+    </xsl:if>
+  </xsl:template>
+
+
+  <xsl:template match="d:author[d:orgname]|d:editor[d:orgname]|d:othercredit[d:orgname]" mode="article.titlepage.recto.auto.mode">
+    <xsl:param name="withlabel" select="1"/>
+    <fo:block>
+      <xsl:apply-templates select="d:orgname"/>
+      <xsl:if test="d:affiliation">
+        <xsl:text>, </xsl:text>
+        <xsl:apply-templates select="d:affiliation/d:jobtitle" mode="article.titlepage.recto.auto.mode"/>
+        <xsl:apply-templates select="d:affiliation/d:orgname" mode="article.titlepage.recto.auto.mode"/>
+      </xsl:if>
+      <!-- In case we want e-mail addresses: -->
+      <!--<xsl:apply-templates select="d:email" mode="article.titlepage.recto.auto.mode"/>-->
+    </fo:block>
+  </xsl:template>
+
+
+  <xsl:template match="d:affiliation/d:jobtitle"  mode="article.titlepage.recto.auto.mode">
+    <xsl:apply-templates/>
+  </xsl:template>
+  <xsl:template match="d:affiliation/d:orgname"  mode="article.titlepage.recto.auto.mode">
+    <xsl:text> (</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>)</xsl:text>
+  </xsl:template>
+
+
+  <!-- Verso page -->
+  <xsl:template name="article.titlepage.verso">
+    <fo:block break-after="page"/>
+    <fo:block space-after="2em">
+      <xsl:choose>
+          <xsl:when test="d:artheader/d:title">
+            <xsl:apply-templates mode="article.titlepage.verso.mode"
+              select="d:artheader/d:title" />
+          </xsl:when>
+          <xsl:when test="d:info/d:title">
+            <xsl:apply-templates mode="article.titlepage.verso.mode"
+              select="d:info/d:title" />
+          </xsl:when>
+          <xsl:when test="d:title">
+            <xsl:apply-templates mode="article.titlepage.verso.mode"
+              select="d:title" />
+          </xsl:when>
+        </xsl:choose>
+      <fo:block space-before="0.75em">
+        <xsl:choose>
+          <xsl:when test="d:artheader/d:subtitle">
+            <xsl:apply-templates mode="article.titlepage.recto.mode"
+              select="d:artheader/d:subtitle" />
+          </xsl:when>
+          <xsl:when test="d:info/d:subtitle">
+            <xsl:apply-templates mode="article.titlepage.recto.mode"
+              select="d:info/d:subtitle" />
+          </xsl:when>
+          <xsl:when test="d:subtitle">
+            <xsl:apply-templates mode="article.titlepage.recto.mode"
+              select="d:subtitle" />
+          </xsl:when>
+        </xsl:choose>
+      </fo:block>
+    </fo:block>
+
+    <xsl:apply-templates mode="article.titlepage.verso.mode" select="d:info/d:abstract"/>
+  </xsl:template>
+
+  <xsl:template match="d:title" mode="article.titlepage.verso.mode">
+    <fo:block font-size="&large;" role="title-article.titlepage.verso.mode">
+      <xsl:apply-templates/>
+    </fo:block>
+  </xsl:template>
+
+  <xsl:template match="d:subtitle" mode="article.titlepage.verso.mode">
+    <fo:block font-size="&normal;" role="subtitle-article.titlepage.verso.mode">
+      <xsl:apply-templates/>
+    </fo:block>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/sbp/fo/colors.ent
+++ b/sbp/fo/colors.ent
@@ -1,0 +1,1 @@
+../../suse2022-ns/fo/colors.ent

--- a/sbp/fo/docbook.xsl
+++ b/sbp/fo/docbook.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Purpose:
+     Transform DocBook document into XSL-FO file
+
+   Target:
+     SUSE Best Practices
+
+   Changes from the standard SUSE stylesheets:
+     * Titlepage
+
+   Input:
+     DocBook 5 document
+
+   Output:
+     Single XSL-FO file
+
+   See Also:
+     * http://doccookbook.sf.net/html/en/dbc.common.dbcustomize.html
+     * http://sagehill.net/docbookxsl/CustomMethods.html#WriteCustomization
+
+   Authors:    Thomas Schraitle <toms@opensuse.org>
+   Copyright:  2022 Thomas Schraitle
+
+-->
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:fo="http://www.w3.org/1999/XSL/Format">
+
+  <xsl:import href="../../suse2022-ns/fo/docbook.xsl"/>
+
+  <xsl:include href="article.titlepage.templates.xsl"/>
+</xsl:stylesheet>

--- a/sbp/fo/fonts.ent
+++ b/sbp/fo/fonts.ent
@@ -1,0 +1,1 @@
+../../suse2022-ns/fo/fonts.ent

--- a/sbp/fo/metrics.ent
+++ b/sbp/fo/metrics.ent
@@ -1,0 +1,1 @@
+../../suse2022-ns/fo/metrics.ent

--- a/sbp/fo/titlepage.templates.xsl
+++ b/sbp/fo/titlepage.templates.xsl
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+-->
+
+<!DOCTYPE xsl:stylesheet
+[
+  <!ENTITY % fonts SYSTEM "fonts.ent">
+  <!ENTITY % colors SYSTEM "colors.ent">
+  <!ENTITY % metrics SYSTEM "metrics.ent">
+  %fonts;
+  %colors;
+  %metrics;
+]>
+
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:fo="http://www.w3.org/1999/XSL/Format">
+
+  <xsl:template name="article.titlepage.recto">
+    <xsl:variable name="height">
+      <xsl:call-template name="get.value.from.unit">
+        <xsl:with-param name="string" select="$page.height"/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="unit">
+      <xsl:call-template name="get.unit.from.unit">
+        <xsl:with-param name="string" select="$page.height"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <fo:block space-after="&gutter;mm" text-align="start">
+      <xsl:choose>
+        <xsl:when test="$writing.mode ='rl'">
+          <xsl:attribute name="margin-right">
+            <xsl:value-of select="&columnfragment; + &gutter;"/>mm
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:attribute name="margin-left">
+            <xsl:value-of select="&columnfragment; + &gutter;"/>mm
+          </xsl:attribute>
+        </xsl:otherwise>
+      </xsl:choose>
+      <fo:instream-foreign-object content-width="{$titlepage.logo.width.article}"
+        width="{$titlepage.logo.width}">
+        <xsl:call-template name="logo-image"/>
+      </fo:instream-foreign-object>
+    </fo:block>
+
+    <fo:block start-indent="{&columnfragment; + &gutter;}mm" text-align="start"
+      role="article.titlepage.recto">
+      <fo:block space-after="{&gutterfragment;}mm">
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
+              select="*[concat(local-name(.), 'info')]/d:productname[not(@role='abbrev')]"/>
+        <xsl:choose>
+          <xsl:when test="d:articleinfo/d:title">
+            <xsl:apply-templates
+              mode="article.titlepage.recto.auto.mode"
+              select="d:articleinfo/d:title"/>
+          </xsl:when>
+          <xsl:when test="d:artheader/d:title">
+            <xsl:apply-templates
+              mode="article.titlepage.recto.auto.mode"
+              select="d:artheader/d:title"/>
+          </xsl:when>
+          <xsl:when test="d:info/d:title">
+            <xsl:apply-templates
+              mode="article.titlepage.recto.auto.mode"
+              select="d:info/d:title"/>
+          </xsl:when>
+          <xsl:when test="d:title">
+            <xsl:apply-templates
+              mode="article.titlepage.recto.auto.mode" select="d:title"/>
+          </xsl:when>
+        </xsl:choose>
+      </fo:block>
+
+    <fo:block padding-before="{2 * &gutterfragment;}mm"
+      padding-start="{&column; + &columnfragment; + &gutter;}mm">
+
+      <xsl:choose>
+        <xsl:when test="d:articleinfo/d:subtitle">
+          <xsl:apply-templates
+            mode="article.titlepage.recto.auto.mode"
+            select="d:articleinfo/d:subtitle"/>
+        </xsl:when>
+        <xsl:when test="d:artheader/d:subtitle">
+          <xsl:apply-templates
+            mode="article.titlepage.recto.auto.mode"
+            select="d:artheader/d:subtitle"/>
+        </xsl:when>
+        <xsl:when test="d:info/d:subtitle">
+          <xsl:apply-templates
+            mode="article.titlepage.recto.auto.mode"
+            select="d:info/d:subtitle"/>
+        </xsl:when>
+        <xsl:when test="d:subtitle">
+          <xsl:apply-templates
+            mode="article.titlepage.recto.auto.mode"
+            select="d:subtitle"/>
+        </xsl:when>
+      </xsl:choose>
+    </fo:block>
+
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:corpauthor"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:corpauthor"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:authorgroup"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:authorgroup"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:author"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:author"/>
+
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:cover"/>
+
+    <xsl:choose>
+      <xsl:when test="d:articleinfo/d:abstract or d:info/d:abstract">
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:abstract"/>
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:abstract"/>
+      </xsl:when>
+      <xsl:when test="d:abstract">
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:abstract"/>
+      </xsl:when>
+    </xsl:choose>
+
+    <fo:block>
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode"  select="d:articleinfo/d:othercredit"/>
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode"  select="d:info/d:othercredit"/>
+    </fo:block>
+
+    <fo:block>
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:editor"/>
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:editor"/>
+    </fo:block>
+
+    <fo:block>
+      <xsl:call-template name="date.and.revision"/>
+    </fo:block>
+
+    <fo:block>
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:mediaobject"/>
+    </fo:block>
+    </fo:block>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/sbp/images/draft.svg
+++ b/sbp/images/draft.svg
@@ -1,0 +1,1 @@
+../../suse2022-ns/images/draft.svg

--- a/sbp/images/sbp-tools-title.svg
+++ b/sbp/images/sbp-tools-title.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="210mm" height="39.66" viewBox="0 0 210 10.49">
+    <g transform="translate(-5.66 -61) scale(.86996)">
+        <path fill="#fe7c3f" stroke="#30ba78" stroke-width=".38" d="M6.5 76.73h156.71m7.68 0h77.14"/>
+        <path fill="#0c322c" stroke="#0c322c" stroke-width=".64" d="M6.5 79.38h153.71"/>
+        <g stroke="#0c322c" data-name="Group 15" transform="translate(162.56 72.16) scale(.63607)">
+            <path fill="none" stroke-miterlimit="10" d="M19.27 3.02h115.09" data-name="Path 73"/>
+            <g transform="translate(-4.48 -5.69) scale(.0957)">
+                <path fill="none" stroke-miterlimit="10" stroke-width="10.5" d="m145.4 124.1 18.2-18.2c14.5 6.6 32.1 4.1 43.9-7.7 9.6-9.6 13.1-23 10.5-35.5L198.1 81l-29.2.1.1-29.2L187.3 32a38.9 38.9 0 0 0-35.5 10.5 38.93 38.93 0 0 0-7.7 43.9l-15.9 15.9m-36 36-57 57c-5.4 5.4-5.4 14.1 0 19.5s14.1 5.4 19.5 0l56.4-56.4"/>
+                <path fill="none" stroke="#30ba78" stroke-miterlimit="10" stroke-width="10.5" d="m134.1 159.6-4.5 3.9 43.3 48.9a14.5 14.5 0 0 0 20.7 1.1c5.9-5.4 6.4-14.5 1.1-20.5l-43.1-48.3-4.2 3.5-56.3-66.1-.5-14-22.9-17.5-17 14.4 13.6 25.4 13.4 3z"/>
+            </g>
+        </g>
+    </g>
+</svg>
+

--- a/sbp/static/css
+++ b/sbp/static/css
@@ -1,0 +1,1 @@
+../../suse2022-ns/static/css

--- a/sbp/static/images
+++ b/sbp/static/images
@@ -1,0 +1,1 @@
+../../suse2022-ns/static/images

--- a/sbp/static/js
+++ b/sbp/static/js
@@ -1,0 +1,1 @@
+../../suse2022-ns/static/js

--- a/sbp/xhtml/chunk.xsl
+++ b/sbp/xhtml/chunk.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+   Purpose:
+     Transform DocBook document into single XHTML file
+
+   Target:
+     SUSE Best Practices
+
+   Changes from the standard SUSE stylesheets:
+    * Titlepage
+
+   Input:
+     DocBook 5 document
+
+   Output:
+     Chunked XHTML files
+
+   See Also:
+     * http://doccookbook.sf.net/html/en/dbc.common.dbcustomize.html
+     * http://sagehill.net/docbookxsl/CustomMethods.html#WriteCustomization
+
+   Authors:    Thomas Schraitle <toms@opensuse.org>
+   Copyright:  2022 Thomas Schraitle
+
+-->
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:import href="docbook.xsl"/>
+  <xsl:import href="../../suse2022-ns/xhtml/chunk-common.xsl"/>
+  <xsl:include href="http://docbook.sourceforge.net/release/xsl-ns/current/xhtml/manifest.xsl"/>
+  <xsl:include href="http://docbook.sourceforge.net/release/xsl-ns/current/xhtml/chunk-code.xsl"/>
+
+  <xsl:param name="is.chunk" select="1"/>
+
+</xsl:stylesheet>

--- a/sbp/xhtml/docbook.xsl
+++ b/sbp/xhtml/docbook.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Purpose:
+     Transform DocBook document into single XHTML file
+
+   Target:
+     SUSE Best Practices
+
+   Changes from the standard SUSE stylesheets:
+     * Titlepages contains now a list of authors and company logos
+
+   Input:
+     DocBook 5 document
+
+   Output:
+     Single XHTML file
+
+   See Also:
+     * http://doccookbook.sf.net/html/en/dbc.common.dbcustomize.html
+     * http://sagehill.net/docbookxsl/CustomMethods.html#WriteCustomization
+
+   Authors:    Thomas Schraitle <toms@opensuse.org>
+   Copyright:  2022 Thomas Schraitle
+
+-->
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:d="http://docbook.org/ns/docbook"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns="http://www.w3.org/1999/xhtml"
+    exclude-result-prefixes="exsl d">
+
+  <xsl:import href="../../suse2022-ns/xhtml/docbook.xsl"/>
+
+  <xsl:include href="titlepage.templates.xsl"/>
+
+</xsl:stylesheet>

--- a/sbp/xhtml/titlepage.templates.xsl
+++ b/sbp/xhtml/titlepage.templates.xsl
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Purpose:
+     The title page for articles
+
+
+
+   Authors:    Thomas Schraitle <toms@opensuse.org>
+   Copyright:  2022 Thomas Schraitle
+-->
+
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:exsl="http://exslt.org/common"
+  xmlns="http://www.w3.org/1999/xhtml"
+  exclude-result-prefixes="exsl d">
+
+  <xsl:template name="add.authorgroup">
+    <div>
+      <xsl:call-template name="generate.class.attribute"/>
+      <div>
+        <span class="imprint-label">
+          <xsl:call-template name="gentext">
+            <xsl:with-param name="key">
+              <xsl:choose>
+                <xsl:when test="count(d:author|d:corpauthor) > 1">Authors</xsl:when>
+                <xsl:otherwise>Author</xsl:otherwise>
+              </xsl:choose>
+            </xsl:with-param>
+          </xsl:call-template>
+        </span>
+        <xsl:for-each select="d:author">
+          <xsl:apply-templates select="." mode="article.titlepage.recto.auto.mode">
+            <xsl:with-param name="withlabel" select="0"/>
+          </xsl:apply-templates>
+        </xsl:for-each>
+      </div>
+    </div>
+    <xsl:if test="d:othercredit|d:editor">
+      <xsl:call-template name="add.othercredit"/>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="add.othercredit">
+    <div class="othercredit">
+      <xsl:call-template name="generate.class.attribute"/>
+      <span class="imprint-label">
+        <xsl:call-template name="gentext">
+          <xsl:with-param name="key">
+            <xsl:choose>
+              <xsl:when test="count(d:othercredit|d:editor) > 1"
+                >Contributors</xsl:when>
+              <xsl:otherwise>Contributor</xsl:otherwise>
+            </xsl:choose>
+          </xsl:with-param>
+        </xsl:call-template>
+      </span>
+      <xsl:for-each select="d:editor|d:othercredit">
+        <xsl:apply-templates select="." mode="article.titlepage.recto.auto.mode">
+          <xsl:with-param name="withlabel" select="0"/>
+        </xsl:apply-templates>
+      </xsl:for-each>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="d:author[d:personname]|d:editor[d:personname]|d:othercredit[d:personname]" mode="article.titlepage.recto.auto.mode">
+    <xsl:param name="withlabel" select="1"/>
+    <div>
+      <xsl:call-template name="generate.class.attribute"/>
+      <xsl:if test="$withlabel != 0">
+        <span class="imprint-label">
+          <xsl:call-template name="gentext">
+            <xsl:with-param name="key">Author</xsl:with-param>
+          </xsl:call-template>
+        </span>
+      </xsl:if>
+
+      <xsl:call-template name="person.name">
+        <xsl:with-param name="node" select="."/>
+      </xsl:call-template>
+
+      <xsl:if test="d:affiliation">
+        <xsl:text>, </xsl:text>
+        <xsl:apply-templates select="d:affiliation/d:jobtitle" mode="article.titlepage.recto.auto.mode"/>
+        <xsl:apply-templates select="d:affiliation/d:orgname" mode="article.titlepage.recto.auto.mode"/>
+      </xsl:if>
+    </div>
+  </xsl:template>
+
+
+  <xsl:template match="d:author[d:orgname]|d:editor[d:orgname]|d:othercredit[d:orgname]" mode="article.titlepage.recto.auto.mode">
+    <xsl:param name="withlabel" select="1"/>
+    <div>
+      <xsl:call-template name="generate.class.attribute"/>
+      <xsl:apply-templates select="d:orgname"/>
+      <xsl:if test="d:affiliation">
+        <xsl:text>, </xsl:text>
+        <xsl:apply-templates select="d:affiliation/d:jobtitle" mode="article.titlepage.recto.auto.mode"/>
+        <xsl:apply-templates select="d:affiliation/d:orgname" mode="article.titlepage.recto.auto.mode"/>
+      </xsl:if>
+      <!-- In case we want e-mail addresses: -->
+      <!--<xsl:apply-templates select="d:email" mode="article.titlepage.recto.auto.mode"/>-->
+    </div>
+  </xsl:template>
+
+
+  <xsl:template match="d:affiliation/d:jobtitle"  mode="article.titlepage.recto.auto.mode">
+    <xsl:apply-templates/>
+  </xsl:template>
+  <xsl:template match="d:affiliation/d:orgname"  mode="article.titlepage.recto.auto.mode">
+    <xsl:text> (</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>)</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="d:cover" mode="article.titlepage.recto.auto.mode">
+    <div class="cover">
+      <xsl:apply-templates select="*"/>
+    </div>
+  </xsl:template>
+
+  <xsl:template name="_article.titlepage.before.recto">
+
+<!--    <xsl:call-template name="version.info.page-top"/>-->
+    <xsl:call-template name="version.info.headline"/>
+  </xsl:template>
+
+
+  <xsl:template name="article.titlepage.recto">
+    <xsl:choose>
+      <xsl:when test="d:articleinfo/d:title">
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:title"/>
+      </xsl:when>
+      <xsl:when test="d:artheader/d:title">
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:artheader/d:title"/>
+      </xsl:when>
+      <xsl:when test="d:info/d:title">
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:title"/>
+      </xsl:when>
+      <xsl:when test="d:title">
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:title"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="fallback.title"/>
+      </xsl:otherwise>
+    </xsl:choose>
+
+    <xsl:choose>
+      <xsl:when test="d:articleinfo/d:subtitle">
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:subtitle"/>
+      </xsl:when>
+      <xsl:when test="d:artheader/d:subtitle">
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:artheader/d:subtitle"/>
+      </xsl:when>
+      <xsl:when test="d:info/d:subtitle">
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:subtitle"/>
+      </xsl:when>
+      <xsl:when test="d:subtitle">
+        <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:subtitle"/>
+      </xsl:when>
+    </xsl:choose>
+
+    <div class="series-category">
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:meta[@name='series']"/>
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:meta[@name='category']"/>
+    </div>
+
+    <!-- Moved authors and authorgroups here: -->
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:artheader/d:corpauthor"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:corpauthor"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:artheader/d:authorgroup"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:authorgroup"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:artheader/d:author"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:author"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:artheader/d:othercredit"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:othercredit"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:editor"/>
+
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:cover"/>
+
+    <div class="platforms">
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:meta[@name='platform']"/>
+    </div>
+
+    <!-- Legal notice removed from here, now positioned at the bottom of the page, see: division.xsl -->
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:artheader/d:abstract"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:abstract"/>
+
+    <xsl:call-template name="date.and.revision"/>
+    <xsl:call-template name="vcs.url"/>
+
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:artheader/d:copyright"/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:copyright"/>
+  </xsl:template>
+
+  <xsl:template match="d:meta" name="meta">
+    <xsl:param name="class" select="@name"/><!-- default -->
+    <xsl:param name="element">div</xsl:param>
+    <xsl:element name="{$element}">
+      <xsl:call-template name="generate.class.attribute">
+        <xsl:with-param name="class" select="$class"/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="d:meta[@name='series']" mode="article.titlepage.recto.auto.mode">
+    <xsl:apply-templates select="."/>
+  </xsl:template>
+
+  <xsl:template match="d:meta[@name='category']" mode="article.titlepage.recto.auto.mode">
+    <xsl:apply-templates select="."/>
+  </xsl:template>
+
+  <xsl:template match="d:meta[@name='platform']" mode="article.titlepage.recto.auto.mode">
+    <div>
+      <xsl:call-template name="generate.class.attribute">
+        <xsl:with-param name="class" select="@name"/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/source-assets/styles2022/sass/custom/content-title.sass
+++ b/source-assets/styles2022/sass/custom/content-title.sass
@@ -202,3 +202,32 @@ h2
 
   &:hover
     background: url($title_icons_path + 'report-bug-dark.svg') no-repeat
+
+
+.titlepage
+  .authorgroup:nth-child(1)
+    margin-top: 3rem
+  
+  // .authorgroup:nth-child(2)
+  //  margin-top: 2rem
+  
+  .series-category
+    text-align: right
+    font-size: 1.25rem
+    margin-top: 3rem
+    margin-bottom: 3rem
+
+
+.cover
+  margin-top: 2rem
+  display: flex
+  gap: 1.25rem
+  justify-content: flex-start
+
+  .mediaobject
+    // border: 1pt solid #eee
+    padding: 3pt
+    width:   5rem
+
+.platforms
+  margin-top: 2rem

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -2420,6 +2420,27 @@ h2 {
   .icon-reportbug:hover {
     background: url("../images/report-bug-dark.svg") no-repeat; }
 
+.titlepage .authorgroup:nth-child(1) {
+  margin-top: 3rem; }
+
+.titlepage .series-category {
+  text-align: right;
+  font-size: 1.25rem;
+  margin-top: 3rem;
+  margin-bottom: 3rem; }
+
+.cover {
+  margin-top: 2rem;
+  display: flex;
+  gap: 1.25rem;
+  justify-content: flex-start; }
+  .cover .mediaobject {
+    padding: 3pt;
+    width: 5rem; }
+
+.platforms {
+  margin-top: 2rem; }
+
 .informaltable,
 .table-contents {
   overflow: auto; }

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -8,7 +8,7 @@
      http://docbook.sourceforge.net/release/xsl-ns/current/doc/html/index.html
 
    Input:
-     DocBook 4/5 document
+     DocBook 5 document
 
    Output:
      Single XHTML file
@@ -19,7 +19,7 @@
 
    Authors:    Thomas Schraitle <toms@opensuse.org>,
                Stefan Knorr <sknorr@suse.de>
-   Copyright:  2012-2018 Thomas Schraitle, Stefan Knorr
+   Copyright:  2012-2022 Thomas Schraitle, Stefan Knorr
 
 -->
 


### PR DESCRIPTION
Create SBP stylesheets structure for FO/XHTML
    
* Base SBP stylesheets on suse2022-ns
* Change article titlepage for XHTML
    - Change order of authors and abstract
    - List job title and company name for every author
* Supports authorgroup and author for titlepage
* Supports affiliation/jobtitle and affiliation/orgname in author, editor, and othercredit. Distinguish between a personname and an  orgname

# First draft

<details>
  <summary>PDF titlepage (click me)</summary>

![Screenshot_20221111_170029](https://user-images.githubusercontent.com/1312925/201382083-61e824be-210e-4f5d-92ea-6d14af5af40f.png)

</details>


# Related issue

DOCTEAM-522

# TODOs
* Select the element that becomes the series name and category/document type
* Check layout with @chabowski 