### PR TITLE
HTML: Make more space for cover icons

### DIFF
--- a/source-assets/styles2022/sass/custom/content-title.sass
+++ b/source-assets/styles2022/sass/custom/content-title.sass
@@ -228,7 +228,7 @@ h2
   .mediaobject
     // border: 1pt solid #eee
     padding: 3pt
-    width:   5rem
+    width:   10rem
 
 .platforms
   margin-top: 2rem

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -2437,7 +2437,7 @@ h2 {
   justify-content: flex-start; }
   .cover .mediaobject {
     padding: 3pt;
-    width: 5rem; }
+    width: 10rem; }
 
 .platforms {
   margin-top: 2rem; }


### PR DESCRIPTION
The cover icons are quite small. This fix allows them to grow bigger.