### PR TITLE
Fix #526: add book titlepage for TRD stylesheets

### DIFF
--- a/sbp/fo/article.titlepage.templates.xsl
+++ b/sbp/fo/article.titlepage.templates.xsl
@@ -47,10 +47,6 @@
     <!-- Title -->
     <fo:block space-before="3cm" hyphenate="false" text-align="left">
       <xsl:choose>
-        <xsl:when test="d:artheader/d:title">
-          <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
-            select="d:artheader/d:title" />
-        </xsl:when>
         <xsl:when test="d:info/d:title">
           <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
             select="d:info/d:title" />
@@ -64,10 +60,6 @@
     <!-- Subtitle -->
     <fo:block space-before="0.75em" hyphenate="false" text-align="left">
       <xsl:choose>
-        <xsl:when test="d:artheader/d:subtitle">
-          <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
-            select="d:artheader/d:subtitle" />
-        </xsl:when>
         <xsl:when test="d:info/d:subtitle">
           <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
             select="d:info/d:subtitle" />

--- a/trd/fo/book.titlepage.templates.xsl
+++ b/trd/fo/book.titlepage.templates.xsl
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+-->
+
+<!DOCTYPE xsl:stylesheet
+[
+  <!ENTITY % fonts SYSTEM "fonts.ent">
+  <!ENTITY % colors SYSTEM "colors.ent">
+  <!ENTITY % metrics SYSTEM "metrics.ent">
+  %fonts;
+  %colors;
+  %metrics;
+]>
+
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:fo="http://www.w3.org/1999/XSL/Format"
+  xmlns:exsl="http://exslt.org/common"
+  exclude-result-prefixes="d exsl">
+
+
+  <!-- Recto page -->
+  <xsl:template name="book.titlepage.recto">
+    <fo:table>
+      <fo:table-column column-number="1" column-width="10%"/>
+      <fo:table-column column-number="2" column-width="90%"/>
+      <fo:table-body>
+        <fo:table-cell text-align="start">
+          <fo:block>
+            <fo:instream-foreign-object
+              content-width="{$titlepage.logo.width.article}"
+              width="{$titlepage.logo.width}">
+              <xsl:call-template name="logo-image" />
+            </fo:instream-foreign-object>
+          </fo:block>
+        </fo:table-cell>
+        <fo:table-cell text-align="right" color="&c_jungle;">
+          <fo:block font-size="&xxx-large;pt">
+            <xsl:apply-templates select="d:info/d:meta[@name='series'][1]" mode="book.titlepage.recto.auto.mode"/>
+          </fo:block>
+          <fo:block font-size="&large;pt">
+            <xsl:apply-templates select="d:info/d:meta[@name='category'][1]" mode="book.titlepage.recto.auto.mode"/>
+          </fo:block>
+        </fo:table-cell>
+      </fo:table-body>
+    </fo:table>
+
+    <!-- Title -->
+    <fo:block space-before="3cm" hyphenate="false" text-align="left">
+      <xsl:choose>
+        <xsl:when test="d:info/d:title">
+          <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:title" />
+        </xsl:when>
+        <xsl:when test="d:title">
+          <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:title" />
+        </xsl:when>
+      </xsl:choose>
+    </fo:block>
+    <!-- Subtitle -->
+    <fo:block space-before="0.75em" hyphenate="false" text-align="left">
+      <xsl:choose>
+        <xsl:when test="d:info/d:subtitle">
+          <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:subtitle" />
+        </xsl:when>
+        <xsl:when test="d:subtitle">
+          <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:subtitle" />
+        </xsl:when>
+      </xsl:choose>
+    </fo:block>
+
+    <!--  -->
+    <!--<fo:block-container absolute-position="fixed" top="{$page.margin.top} + 6.75cm" left="0" right="{$page.width}"
+      role="titlepage.logo">
+      <fo:block>
+        <fo:external-graphic content-width="100%" src="{$titlepage.logo.image}" />
+      </fo:block>
+    </fo:block-container>-->
+
+    <fo:block margin-left="-2cm">
+      <fo:external-graphic left="0" right="{$page.margin.outer}"
+        content-width="100%" src="{$titlepage.logo.image}" />
+    </fo:block>
+
+    <!-- Platform specific -->
+    <fo:block space-before="2em" text-align="right" font-size="&normal;pt">
+      <xsl:apply-templates select="d:info/d:meta[@name='platform']" mode="book.titlepage.recto.auto.mode"/>
+    </fo:block>
+
+    <!-- Authors -->
+    <fo:block space-before="4em" font-size="&normal;pt">
+      <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
+        select="d:info/d:authorgroup" />
+      <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
+        select="d:info/d:author[1]" />
+    </fo:block>
+
+    <!-- Cover Icons -->
+    <fo:block-container absolute-position="absolute" top="{$page.height.portrait} * 0.78">
+      <fo:block>
+        <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
+          select="d:info/d:cover[d:mediaobject]" />
+      </fo:block>
+    </fo:block-container>
+  </xsl:template>
+
+  <!-- ======== -->
+  <xsl:template match="d:cover[d:mediaobject]" mode="book.titlepage.recto.auto.mode">
+    <xsl:variable name="n" select="count(d:mediaobject)"/>
+    <xsl:if test="count(d:mediaobject) > 5">
+      <!-- We only allow max 5 icons -->
+      <xsl:message terminate="yes">ERROR: There are more than 5 icons on the cover page.</xsl:message>
+    </xsl:if>
+
+    <fo:table role="cover">
+      <fo:table-body>
+        <!-- Cell no. 1 -->
+        <fo:table-cell>
+          <fo:block>
+            <xsl:apply-templates select="d:mediaobject[last() -4]" mode="book.titlepage.recto.auto.mode"/>
+          </fo:block>
+        </fo:table-cell>
+        <!-- Cell no. 2 -->
+        <fo:table-cell>
+          <fo:block><xsl:apply-templates select="d:mediaobject[last() -3]" mode="book.titlepage.recto.auto.mode"/></fo:block>
+        </fo:table-cell>
+        <!-- Cell no. 3 -->
+        <fo:table-cell>
+          <fo:block><xsl:apply-templates select="d:mediaobject[last() -2]" mode="book.titlepage.recto.auto.mode"/></fo:block>
+        </fo:table-cell>
+        <!-- Cell no. 4 -->
+        <fo:table-cell>
+          <fo:block><xsl:apply-templates select="d:mediaobject[last() -1]" mode="book.titlepage.recto.auto.mode"/></fo:block>
+        </fo:table-cell>
+        <!-- Cell no. 5 -->
+        <fo:table-cell>
+          <fo:block><xsl:apply-templates select="d:mediaobject[last()]" mode="book.titlepage.recto.auto.mode"/></fo:block>
+        </fo:table-cell>
+      </fo:table-body>
+    </fo:table>
+  </xsl:template>
+
+  <xsl:template match="d:cover/d:mediaobject" mode="book.titlepage.recto.auto.mode">
+    <xsl:param name="pos"/>
+      <fo:block>
+        <xsl:apply-templates select="."/>
+      </fo:block>
+  </xsl:template>
+
+  <xsl:template match="d:meta[@name='series']" mode="book.titlepage.recto.auto.mode">
+    <fo:block font-family="{$sans-stack}">
+      <xsl:apply-templates/>
+    </fo:block>
+  </xsl:template>
+
+  <xsl:template match="d:authorgroup" mode="book.titlepage.recto.auto.mode">
+    <fo:block text-align="outside" font-family="{$sans-stack}">
+      <xsl:for-each select="d:author">
+        <fo:block>
+          <xsl:apply-templates select="." mode="authorgroup">
+            <xsl:with-param name="withlabel" select="0" />
+          </xsl:apply-templates>
+        </fo:block>
+        </xsl:for-each>
+
+      <xsl:for-each select="d:editor|d:othercredit">
+        <fo:block>
+          <xsl:apply-templates select="." mode="authorgroup">
+            <xsl:with-param name="withlabel" select="0" />
+          </xsl:apply-templates>
+        </fo:block>
+      </xsl:for-each>
+    </fo:block>
+  </xsl:template>
+
+  <xsl:template match="d:author[1]" mode="book.titlepage.recto.auto.mode">
+    <xsl:variable name="rtf.authorgroup">
+      <d:authorgroup>
+        <xsl:copy-of select=". | following-sibling::d:author"/>
+        <xsl:copy-of select="preceding-sibling::d:editor"/>
+        <xsl:copy-of select="following-sibling::d:editor"/>
+        <xsl:copy-of select="preceding-sibling::d:othercredit"/>
+        <xsl:copy-of select="following-sibling::d:othercredit"/>
+      </d:authorgroup>
+    </xsl:variable>
+    <xsl:variable name="authorgroup" select="exsl:node-set($rtf.authorgroup)"/>
+
+    <!--<xsl:message>author[1] mode="article.titlepage.recto.auto.mode"
+      content of authorgroup = <xsl:value-of select="count($authorgroup/*/*)"/>
+      following-sibling::d:author=<xsl:value-of select="count(following-sibling::d:author)"/>
+
+      following-sibling::d:editor=<xsl:value-of select="count(following-sibling::d:editor)"/>
+      preceding-sibling::d:editor=<xsl:value-of select="count(preceding-sibling::d:editor)"/>
+      following-sibling::d:othercredit=<xsl:value-of select="count(following-sibling::d:othercredit)"/>
+      preceding-sibling::d:othercredit=<xsl:value-of select="count(preceding-sibling::d:othercredit)"/>
+    </xsl:message>-->
+
+    <!-- Delegate all collected nodes to the authorgroup template -->
+    <xsl:apply-templates select="$authorgroup" mode="book.titlepage.recto.auto.mode"/>
+  </xsl:template>
+
+  <xsl:template match="d:title" mode="book.titlepage.recto.auto.mode">
+    <fo:block font-size="{&super-large; * $sans-fontsize-adjust}pt" line-height="{$base-lineheight * 0.85}em"
+      xsl:use-attribute-sets="book.titlepage.recto.style sans.bold.noreplacement"
+      keep-with-next.within-column="always" space-after="{&gutterfragment;}mm">
+      <xsl:apply-templates select="." mode="book.titlepage.recto.mode"/>
+    </fo:block>
+  </xsl:template>
+
+  <xsl:template match="d:subtitle" mode="book.titlepage.recto.auto.mode">
+    <fo:block font-size="{&xxx-large; * $sans-fontsize-adjust}pt" line-height="{$base-lineheight * 0.85}em"
+      text-align="left"
+      xsl:use-attribute-sets="book.titlepage.recto.style"
+      keep-with-next.within-column="always" space-after="{&gutterfragment;}mm">
+      <xsl:apply-templates select="." mode="book.titlepage.recto.mode"/>
+    </fo:block>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/trd/fo/docbook.xsl
+++ b/trd/fo/docbook.xsl
@@ -31,7 +31,7 @@
 
   <xsl:include href="../VERSION.xsl"/>
   <xsl:include href="param.xsl"/>
-<!--  <xsl:include href="../../sbp/fo/titlepage.templates.xsl"/>-->
   <xsl:include href="article.titlepage.templates.xsl"/>
+  <xsl:include href="book.titlepage.templates.xsl"/>
 
 </xsl:stylesheet>

--- a/trd/fo/param.xsl
+++ b/trd/fo/param.xsl
@@ -15,6 +15,12 @@
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
   exclude-result-prefixes="d">
 
+  <xsl:param name="titlepage.logo.image"><xsl:value-of select="$styleroot"/>images/trd-lightbulb-title.svg</xsl:param>
 
-<xsl:param name="titlepage.logo.image"><xsl:value-of select="$styleroot"/>images/trd-lightbulb-title.svg</xsl:param>
+
+  <xsl:attribute-set name="book.titlepage.recto.style">
+    <xsl:attribute name="font-family"><xsl:value-of select="$title.font.family"/></xsl:attribute>
+    <xsl:attribute name="text-align">left</xsl:attribute>
+    <xsl:attribute name="font-weight">normal</xsl:attribute>
+  </xsl:attribute-set>
 </xsl:stylesheet>

--- a/trd/images/trd-lightbulb-title.svg
+++ b/trd/images/trd-lightbulb-title.svg
@@ -1,14 +1,102 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="794.08" height="41.04" viewBox="0 0 210.1 10.86">
-    <g transform="translate(-5.67 -60.61) scale(.86996)">
-        <path fill="#fe7c3f" stroke="#0c322c" stroke-width=".38" d="M6.5 76.73h157.32m7.67 0h76.54"/>
-        <path fill="none" stroke="#30ba78" stroke-width=".64" d="M6.7 79.37h162.26c.26 0 .6-.32.61-.57v-1.6c0-.31.17-.59.44-.75a2.6 2.6 0 0 0 1.22-2.13"/>
-        <g stroke="#0c322c" stroke-width=".64" data-name="Group 14" transform="translate(29.2)">
-            <path fill="none" stroke="#30ba78" stroke-linecap="square" d="M142.04 72.7a2.59 2.59 0 0 0-2.64-2.53h-1.76A2.59 2.59 0 0 0 135 72.7v1.64c.03.87.5 1.66 1.23 2.12a.9.9 0 0 1 .44.75v1.05" data-name="Path 70"/>
-            <path fill="none" stroke="#30ba78" stroke-linecap="round" d="M136.98 80.4h3.08v.93a.32.32 0 0 1-.32.32h-2.44a.32.32 0 0 1-.31-.32z" data-name="Path 72" paint-order="stroke fill markers"/>
-        </g>
-        <g data-name="Group 15" transform="translate(191.76 72.16) scale(.63607)">
-            <path fill="none" stroke="#30ba78" stroke-miterlimit="10" d="M-38.7 11.62s-.07-7.09-.07-8.29c0-1.9 1.15-2.66 2.02-2.66.87 0 .82.15.82.15l-.02 2.56c-.02 1.47-1.19 1.7-2.65 1.7h-2.52V4c0-.63.28-.98 1.17-.98l10.2.02 118.07-.02" data-name="Path 73"/>
-        </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="10.8585mm"
+   viewBox="0 0 209.99966 10.860001"
+   version="1.1"
+   id="svg18"
+   sodipodi:docname="trd-lightbulb-title.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata24">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs22" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2175"
+     inkscape:window-height="833"
+     id="namedview20"
+     showgrid="false"
+     units="mm"
+     inkscape:zoom="1.606891"
+     inkscape:cx="397.04001"
+     inkscape:cy="20.52"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg18" />
+  <g
+     transform="matrix(0.86996,0,0,0.86996,-5.67,-60.61)"
+     id="g16">
+    <path
+       fill="#fe7c3f"
+       stroke="#0c322c"
+       stroke-width="0.38"
+       d="m 6.5,76.73 h 157.32 m 7.67,0 h 76.54"
+       id="path2" />
+    <path
+       fill="none"
+       stroke="#30ba78"
+       stroke-width="0.64"
+       d="m 6.7,79.37 h 162.26 c 0.26,0 0.6,-0.32 0.61,-0.57 v -1.6 c 0,-0.31 0.17,-0.59 0.44,-0.75 a 2.6,2.6 0 0 0 1.22,-2.13"
+       id="path4" />
+    <g
+       stroke="#0c322c"
+       stroke-width="0.64"
+       data-name="Group 14"
+       transform="translate(29.2)"
+       id="g10">
+      <path
+         fill="none"
+         stroke="#30ba78"
+         stroke-linecap="square"
+         d="m 142.04,72.7 a 2.59,2.59 0 0 0 -2.64,-2.53 h -1.76 A 2.59,2.59 0 0 0 135,72.7 v 1.64 c 0.03,0.87 0.5,1.66 1.23,2.12 a 0.9,0.9 0 0 1 0.44,0.75 v 1.05"
+         data-name="Path 70"
+         id="path6" />
+      <path
+         fill="none"
+         stroke="#30ba78"
+         stroke-linecap="round"
+         d="m 136.98,80.4 h 3.08 v 0.93 a 0.32,0.32 0 0 1 -0.32,0.32 h -2.44 a 0.32,0.32 0 0 1 -0.31,-0.32 z"
+         data-name="Path 72"
+         paint-order="stroke fill markers"
+         id="path8" />
     </g>
+    <g
+       data-name="Group 15"
+       transform="matrix(0.63607,0,0,0.63607,191.76,72.16)"
+       id="g14">
+      <path
+         fill="none"
+         stroke="#30ba78"
+         stroke-miterlimit="10"
+         d="m -38.7,11.62 c 0,0 -0.07,-7.09 -0.07,-8.29 0,-1.9 1.15,-2.66 2.02,-2.66 0.87,0 0.82,0.15 0.82,0.15 l -0.02,2.56 c -0.02,1.47 -1.19,1.7 -2.65,1.7 h -2.52 V 4 c 0,-0.63 0.28,-0.98 1.17,-0.98 l 10.2,0.02 118.07,-0.02"
+         data-name="Path 73"
+         id="path12" />
+    </g>
+  </g>
 </svg>
-

--- a/trd/xhtml/book.titlepage.templates.xsl
+++ b/trd/xhtml/book.titlepage.templates.xsl
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+-->
+
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:exsl="http://exslt.org/common"
+  xmlns="http://www.w3.org/1999/xhtml"
+  exclude-result-prefixes="exsl d">
+
+
+  <xsl:template match="d:cover" mode="book.titlepage.recto.auto.mode">
+    <div class="cover">
+      <xsl:apply-templates select="*"/>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="d:meta[@name='series']" mode="book.titlepage.recto.auto.mode">
+    <xsl:apply-templates select="."/>
+  </xsl:template>
+
+
+  <xsl:template match="d:meta[@name='category' or @name='type']" mode="book.titlepage.recto.auto.mode">
+    <xsl:apply-templates select="."/>
+  </xsl:template>
+
+
+  <xsl:template match="d:meta[@name='platform']" mode="book.titlepage.recto.auto.mode">
+    <div>
+      <xsl:call-template name="generate.class.attribute">
+        <xsl:with-param name="class" select="@name"/>
+      </xsl:call-template>
+      <xsl:apply-templates mode="titlepage.mode"/>
+    </div>
+  </xsl:template>
+
+
+  <xsl:template match="d:affiliation/d:jobtitle"  mode="book.titlepage.recto.auto.mode">
+    <xsl:apply-templates/>
+  </xsl:template>
+  <xsl:template match="d:affiliation/d:orgname"  mode="book.titlepage.recto.auto.mode">
+    <xsl:text> (</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>)</xsl:text>
+  </xsl:template>
+  <xsl:template match="d:info/d:author[1]" mode="book.titlepage.recto.auto.mode">
+    <xsl:variable name="rtf.authorgroup">
+      <d:authorgroup>
+        <xsl:copy-of select=". | following-sibling::d:author"/>
+        <xsl:copy-of select="preceding-sibling::d:editor"/>
+        <xsl:copy-of select="following-sibling::d:editor"/>
+        <xsl:copy-of select="preceding-sibling::d:othercredit"/>
+        <xsl:copy-of select="following-sibling::d:othercredit"/>
+      </d:authorgroup>
+    </xsl:variable>
+    <xsl:variable name="authorgroup" select="exsl:node-set($rtf.authorgroup)"/>
+
+    <xsl:message>author[1] mode="book.titlepage.recto.auto.mode"
+      content of authorgroup = <xsl:value-of select="count($authorgroup/*/*)"/>
+      following-sibling::d:author=<xsl:value-of select="count(following-sibling::d:author)"/>
+
+      following-sibling::d:editor=<xsl:value-of select="count(following-sibling::d:editor)"/>
+      preceding-sibling::d:editor=<xsl:value-of select="count(preceding-sibling::d:editor)"/>
+      following-sibling::d:othercredit=<xsl:value-of select="count(following-sibling::d:othercredit)"/>
+      preceding-sibling::d:othercredit=<xsl:value-of select="count(preceding-sibling::d:othercredit)"/>
+    </xsl:message>
+
+    <!-- Delegate all collected nodes to the authorgroup template -->
+    <xsl:apply-templates select="$authorgroup" mode="book.titlepage.recto.auto.mode"/>
+  </xsl:template>
+
+
+  <xsl:template match="d:info/d:date" mode="book.titlepage.recto.auto.mode">
+    <div class="date">
+      <span class="imprint-label">
+        <xsl:call-template name="gentext">
+          <xsl:with-param name="key">Date</xsl:with-param>
+        </xsl:call-template>
+      </span>
+      <xsl:text>: </xsl:text>
+      <xsl:apply-templates select="." mode="titlepage.mode"/>
+    </div>
+  </xsl:template>
+
+  <!-- XHTML book titlepage -->
+  <xsl:template name="book.titlepage.recto">
+    <xsl:message>book.titlepage.recto</xsl:message>
+    <!-- TITLE -->
+    <xsl:choose>
+      <xsl:when test="d:bookinfo/d:title">
+        <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
+          select="d:bookinfo/d:title" />
+      </xsl:when>
+      <xsl:when test="d:info/d:title">
+        <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
+          select="d:info/d:title" />
+      </xsl:when>
+      <xsl:when test="d:title">
+        <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
+          select="d:title" />
+      </xsl:when>
+    </xsl:choose>
+
+    <!-- SUBTITLE -->
+    <xsl:choose>
+      <xsl:when test="d:bookinfo/d:subtitle">
+        <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
+          select="d:bookinfo/d:subtitle" />
+      </xsl:when>
+      <xsl:when test="d:info/d:subtitle">
+        <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
+          select="d:info/d:subtitle" />
+      </xsl:when>
+      <xsl:when test="d:subtitle">
+        <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
+          select="d:subtitle" />
+      </xsl:when>
+    </xsl:choose>
+
+    <div class="series-category">
+      <xsl:comment/>
+      <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:meta[@name='series']"/>
+      <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:meta[@name='category' or @name='type']"/>
+    </div>
+
+    <!-- Moved authors and authorgroups here: -->
+    <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:authorgroup"/>
+    <!-- We match only the first author and group every author, editor, and othercredit -->
+    <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:author[1]"/>
+
+    <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:cover"/>
+
+    <div class="platforms">
+      <xsl:comment/>
+      <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:meta[@name='platform']"/>
+    </div>
+
+    <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:date"/>
+
+    <!-- Legal notice removed from here, now positioned at the bottom of the page, see: division.xsl -->
+    <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:abstract"/>
+
+    <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:copyright"/>
+
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/trd/xhtml/docbook.xsl
+++ b/trd/xhtml/docbook.xsl
@@ -33,5 +33,6 @@
   <xsl:include href="../VERSION.xsl"/>
   <xsl:include href="param.xsl"/>
   <xsl:include href="../../sbp/xhtml/titlepage.templates.xsl"/>
+  <xsl:include href="book.titlepage.templates.xsl"/>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Identical with a SBP article titlepage. The following elements are shown in this order:

* `d:title`, `d:info/d:title`
* `d:subtitle`, `d:info/d:subtitle`
* `d:info/d:meta[@name='series']`
* `d:info/d:meta[@name='category' or @name='type']`
* `d:info/d:authorgroup`
* `d:info/d:author`
* `d:info/d:cover`
* `d:info/d:meta[@name='platform']`
* `d:info/d:date`
* `d:info/d:abstract`
* `d:info/d:copyright`