### PR TITLE
Support return for keycaps

### DIFF
--- a/suse2022-ns/common/l10n/ar.xml
+++ b/suse2022-ns/common/l10n/ar.xml
@@ -251,12 +251,7 @@ translators apparently want those. - sknorr, 2016-09-30 -->
       <l:template name="part" text="الجزء&#160;%n&#160;%t"/>
    </l:context>
 
-  <!--
-    HACK for keycap context
-    We need to keep this for some time
-    See Ticket#84 and https://sf.net/tracker/index.php?func=detail&aid=3540451&group_id=21935&atid=373750
-   -->
-   <l:context name="msgset">
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/><!-- mdash -->
       <l:template name="command" text="&#x2318;"/>
@@ -274,6 +269,7 @@ translators apparently want those. - sknorr, 2016-09-30 -->
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="الصفحة &#x02193;"/>
       <l:template name="pageup" text="الصفحة &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Shift"/>
       <l:template name="space" text="Space"/>

--- a/suse2022-ns/common/l10n/cs.xml
+++ b/suse2022-ns/common/l10n/cs.xml
@@ -225,7 +225,7 @@
    </l:context>
 
 
-   <l:context name="msgset">
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/><!-- mdash -->
       <l:template name="command" text="&#x2318;"/>
@@ -243,6 +243,7 @@
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="Page &#x02193;"/>
       <l:template name="pageup" text="Page &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Shift"/>
       <l:template name="space" text="Space"/>

--- a/suse2022-ns/common/l10n/da.xml
+++ b/suse2022-ns/common/l10n/da.xml
@@ -190,7 +190,7 @@
    </l:context>
 
 
-   <l:context name="msgset">
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/><!-- mdash -->
       <l:template name="command" text="&#x2318;"/>
@@ -208,6 +208,7 @@
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="Side &#x02193;"/>
       <l:template name="pageup" text="Side &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Skift"/>
       <l:template name="space" text="Mellemrum"/>

--- a/suse2022-ns/common/l10n/de.xml
+++ b/suse2022-ns/common/l10n/de.xml
@@ -174,7 +174,7 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
-   <l:context name="msgset">
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/>
       <l:template name="command" text="&#x2318;"/>
@@ -192,6 +192,7 @@
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="Bild &#x02193;"/>
       <l:template name="pageup" text="Bild &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Umschalttaste"/>
       <l:template name="space" text="Leertaste"/>

--- a/suse2022-ns/common/l10n/en.xml
+++ b/suse2022-ns/common/l10n/en.xml
@@ -181,12 +181,8 @@
       <l:template name="part" text="Part&#160;%n&#160;%t"/>
    </l:context>
 
-  <!--
-    HACK for keycap context
-    We need to keep this for some time
-    See Ticket#84 and https://sf.net/tracker/index.php?func=detail&aid=3540451&group_id=21935&atid=373750
-   -->
-   <l:context name="msgset">
+
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/><!-- mdash -->
       <l:template name="command" text="&#x2318;"/>
@@ -204,6 +200,7 @@
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="Page &#x02193;"/>
       <l:template name="pageup" text="Page &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Shift"/>
       <l:template name="space" text="Space"/>

--- a/suse2022-ns/common/l10n/es.xml
+++ b/suse2022-ns/common/l10n/es.xml
@@ -195,7 +195,7 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
-   <l:context name="msgset">
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/>
       <l:template name="command" text="&#x2318;"/>
@@ -214,6 +214,7 @@
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="P&#xe1;gina &#x02193;"/>
       <l:template name="pageup" text="P&#xe1;gina &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="May&#xfa;s"/>
       <l:template name="space" text="Espacio"/>

--- a/suse2022-ns/common/l10n/fi.xml
+++ b/suse2022-ns/common/l10n/fi.xml
@@ -186,7 +186,7 @@
       <l:template name="part" text="Osa&#160;%n&#160;%t"/>
    </l:context>
 
-   <l:context name="msgset">
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/><!-- mdash -->
       <l:template name="command" text="&#x2318;"/>
@@ -204,6 +204,7 @@
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="Sivu &#x02193;"/>
       <l:template name="pageup" text="Sivu &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Vaihto"/>
       <l:template name="space" text="V&#228;li"/>

--- a/suse2022-ns/common/l10n/fr.xml
+++ b/suse2022-ns/common/l10n/fr.xml
@@ -175,7 +175,7 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
-   <l:context name="msgset">
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/>
       <!--       <l:template name="command" text=""/> -->
@@ -193,6 +193,7 @@
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="Page &#x02193;"/>
       <l:template name="pageup" text="Page &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Maj"/>
       <l:template name="space" text="Space"/>

--- a/suse2022-ns/common/l10n/hu.xml
+++ b/suse2022-ns/common/l10n/hu.xml
@@ -200,7 +200,7 @@
    </l:context>
 
 
-   <l:context name="msgset">
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/><!-- mdash -->
       <l:template name="command" text="&#x2318;"/>
@@ -218,6 +218,7 @@
       <l:template name="other" text=""/>
       <l:template name="pagedown" text="Page &#x02193;"/>
       <l:template name="pageup" text="Page &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Shift"/>
       <l:template name="space" text="Sz&#243;k&#246;z"/>

--- a/suse2022-ns/common/l10n/it.xml
+++ b/suse2022-ns/common/l10n/it.xml
@@ -189,7 +189,7 @@
       <l:template name="format" text="d.m.Y"/>
    </l:context>
 
-   <l:context name="msgset">
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/>
       <l:template name="command" text="&#x2318;"/>
@@ -207,6 +207,7 @@
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="Pagina &#x02193;"/>
       <l:template name="pageup" text="Pagina &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Shift"/>
       <l:template name="space" text="Space"/>

--- a/suse2022-ns/common/l10n/ja.xml
+++ b/suse2022-ns/common/l10n/ja.xml
@@ -194,7 +194,7 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
-   <l:context name="msgset"><!-- FIXME: What are the Japanese keycaps? -->
+   <l:context name="keycap"><!-- FIXME: What are the Japanese keycaps? -->
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/><!-- mdash -->
       <l:template name="command" text="&#x2318;"/>
@@ -212,6 +212,7 @@
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="Page &#x02193;"/>
       <l:template name="pageup" text="Page &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Shift"/>
       <l:template name="space" text="Space"/>

--- a/suse2022-ns/common/l10n/ko.xml
+++ b/suse2022-ns/common/l10n/ko.xml
@@ -204,7 +204,7 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
-   <l:context name="msgset">
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/><!-- mdash -->
       <l:template name="command" text="&#x2318;"/>
@@ -222,6 +222,7 @@
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="Page &#x02193;"/>
       <l:template name="pageup" text="Page &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Shift"/>
       <l:template name="space" text="Space"/>

--- a/suse2022-ns/common/l10n/lt_lt.xml
+++ b/suse2022-ns/common/l10n/lt_lt.xml
@@ -175,7 +175,7 @@
       <l:template name="part" text="%t&#160;%n&#160;dalis"/>
    </l:context>
 
-   <l:context name="msgset">
+   <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&#9003;"/><!-- mdash -->
       <l:template name="command" text="&#x2318;"/>
@@ -192,6 +192,7 @@
       <l:template name="other" text="???"/>
       <l:template name="pagedown" text="Psl &#x02193;"/>
       <l:template name="pageup" text="Psl &#x02191;"/>
+      <l:template name="return" text="↵"/>
       <l:template name="right" text="&#x02192;"/><!-- rarr -->
       <l:template name="shift" text="Lyg2"/>
       <l:template name="space" text="Tarpas"/>

--- a/suse2022-ns/fo/inline.xsl
+++ b/suse2022-ns/fo/inline.xsl
@@ -429,11 +429,7 @@
     <xsl:choose>
       <xsl:when test="@function and normalize-space(.) = ''">
         <xsl:call-template name="gentext.template">
-          <xsl:with-param name="context" select="'msgset'"/>
-            <!-- FIXME suse22: clean up? (We have v1.79.2!)-->
-            <!-- This context is called "keycap" instead in the upcoming
-                 upstream release – TODO: use "keycap" when we've switched to
-                 1.77.2. -->
+          <xsl:with-param name="context" select="'keycap'"/>
           <xsl:with-param name="name" select="@function"/>
         </xsl:call-template>
       </xsl:when>

--- a/suse2022-ns/xhtml/inline.xsl
+++ b/suse2022-ns/xhtml/inline.xsl
@@ -76,7 +76,7 @@
         <xsl:call-template name="inline.sansseq">
           <xsl:with-param name="content">
             <xsl:call-template name="gentext.template">
-              <xsl:with-param name="context" select="'msgset'"/>
+              <xsl:with-param name="context" select="'keycap'"/>
               <xsl:with-param name="name" select="@function"/>
             </xsl:call-template>
           </xsl:with-param>


### PR DESCRIPTION
The "msgset" context has to be replaced by "keycap" as this context is now available in the upstream DocBook stylesheets. This supports code like this:

```xml
<keycap function="return"/>
```

# Related information

* https://sf.net/tracker/index.php?func=detail&aid=3540451&group_id=21935&atid=373750