### PR TITLE
DOCTEAM-633: Preparing SUSE header changes

### DIFF
--- a/suse2022-ns/common/utility.xsl
+++ b/suse2022-ns/common/utility.xsl
@@ -173,4 +173,42 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+
+
+  <!--  -->
+  <xsl:template name="get-lang-for-ssi">
+    <xsl:param name="node" select="."/>
+    <xsl:variable name="lang-scope" select="$node/ancestor-or-self::*[@xml:lang][1]"/>
+
+    <xsl:variable name="lang-attr">
+      <xsl:variable name="lang-tmp" select="($lang-scope/@xml:lang)[1]"/>
+      <xsl:choose>
+        <xsl:when test="$lang-tmp">
+          <xsl:choose>
+            <!-- Rewrite language from simple two-character language code into LANG-COUNTRY-->
+            <xsl:when test="$lang-tmp = 'en'">en-us</xsl:when>
+            <xsl:when test="$lang-tmp = 'cs'">cs-cz</xsl:when>
+            <xsl:when test="$lang-tmp = 'de'">de-de</xsl:when>
+            <xsl:when test="$lang-tmp = 'es'">es-es</xsl:when>
+            <xsl:when test="$lang-tmp = 'fr'">fr-fr</xsl:when>
+            <xsl:when test="$lang-tmp = 'ko'">ko-kr</xsl:when>
+            <xsl:when test="$lang-tmp = 'ja'">ja-jp</xsl:when>
+            <xsl:when test="$lang-tmp = 'pt'">pt-br</xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="$lang-tmp"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:when>
+        <!-- If we haven't found a language, fall back to English: -->
+        <xsl:otherwise>en-us</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <!--<xsl:message>get-lang-for-ssi
+      lang-scope=<xsl:value-of select="count($lang-scope)"/>
+      lang=<xsl:value-of select="($lang-scope/@xml:lang)[1]"/>
+      lang-attr=<xsl:value-of select="$lang-attr"/>
+    </xsl:message>-->
+
+    <xsl:value-of select="$lang-attr"/>
+  </xsl:template>
 </xsl:stylesheet>

--- a/suse2022-ns/xhtml/chunk-common.xsl
+++ b/suse2022-ns/xhtml/chunk-common.xsl
@@ -233,43 +233,57 @@
 
     <xsl:call-template name="user.preroot"/>
 
-    <html lang="{$lang-attr}">
-      <xsl:call-template name="root.attributes"/>
+    <html>
+      <xsl:attribute name="lang">
+        <xsl:choose>
+          <xsl:when test="$rootid">
+            <xsl:call-template name="l10n.language">
+              <xsl:with-param name="target" select="key('id', $rootid)"/>
+            </xsl:call-template>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:call-template name="l10n.language">
+              <xsl:with-param name="target" select="/*[1]"/>
+            </xsl:call-template>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+      <xsl:call-template name="root.attributes" />
       <xsl:call-template name="html.head">
-        <xsl:with-param name="prev" select="$prev"/>
-        <xsl:with-param name="next" select="$next"/>
+        <xsl:with-param name="prev" select="$prev" />
+        <xsl:with-param name="next" select="$next" />
       </xsl:call-template>
 
       <body>
-        <xsl:call-template name="body.attributes"/>
-        <xsl:call-template name="outerelement.class.attribute"/>
+        <xsl:call-template name="body.attributes" />
+        <xsl:call-template name="outerelement.class.attribute" />
         <xsl:if test="$include.suse.header">
           <xsl:variable name="candidate.suse.header.body">
             <xsl:call-template name="string.subst">
-              <xsl:with-param name="string" select="$include.ssi.body"/>
-              <xsl:with-param name="target" select="$placeholder.ssi.language"/>
-              <xsl:with-param name="replacement" select="$lang-attr"/>
+              <xsl:with-param name="string" select="$include.ssi.body" />
+              <xsl:with-param name="target" select="$placeholder.ssi.language" />
+              <xsl:with-param name="replacement" select="$lang-attr" />
             </xsl:call-template>
           </xsl:variable>
           <xsl:text>&#10;</xsl:text>
-          <xsl:comment>#include virtual="<xsl:value-of select="$candidate.suse.header.body"/>"</xsl:comment>
+          <xsl:comment>#include virtual="<xsl:value-of select="$candidate.suse.header.body" />"</xsl:comment>
           <xsl:text>&#10;</xsl:text>
         </xsl:if>
         <xsl:call-template name="bypass">
-          <xsl:with-param name="format" select="'chunk'"/>
+          <xsl:with-param name="format" select="'chunk'" />
         </xsl:call-template>
 
-        <xsl:call-template name="user.header.content"/>
+        <xsl:call-template name="user.header.content" />
 
-        <xsl:call-template name="breadcrumbs.navigation"/>
+        <xsl:call-template name="breadcrumbs.navigation" />
 
         <main id="_content">
 
-          <xsl:call-template name="side.toc.overall"/>
+          <xsl:call-template name="side.toc.overall" />
           <button id="_open-side-toc-overall">
             <xsl:attribute name="title">
               <xsl:call-template name="gentext">
-                <xsl:with-param name="key" select="'TableofContents'"/>
+                <xsl:with-param name="key" select="'TableofContents'" />
               </xsl:call-template>
             </xsl:attribute>
             <xsl:text> </xsl:text>
@@ -279,24 +293,24 @@
 
             <button id="_unfold-side-toc-page">
               <xsl:call-template name="gentext">
-                <xsl:with-param name="key" select="'onthispage'"/>
+                <xsl:with-param name="key" select="'onthispage'" />
               </xsl:call-template>
             </button>
-            <xsl:copy-of select="$content"/>
+            <xsl:copy-of select="$content" />
 
             <xsl:call-template name="bottom.navigation">
-              <xsl:with-param name="prev" select="$prev"/>
-              <xsl:with-param name="next" select="$next"/>
-              <xsl:with-param name="nav.context" select="$nav.context"/>
+              <xsl:with-param name="prev" select="$prev" />
+              <xsl:with-param name="next" select="$next" />
+              <xsl:with-param name="nav.context" select="$nav.context" />
             </xsl:call-template>
 
           </article>
 
-          <xsl:call-template name="side.toc.page"/>
+          <xsl:call-template name="side.toc.page" />
 
         </main>
 
-        <xsl:call-template name="user.footer.content"/>
+        <xsl:call-template name="user.footer.content" />
 
       </body>
     </html>

--- a/suse2022-ns/xhtml/chunk-common.xsl
+++ b/suse2022-ns/xhtml/chunk-common.xsl
@@ -228,20 +228,7 @@
 
     <xsl:variable name="lang-scope" select="ancestor-or-self::*[@xml:lang][1]"/>
     <xsl:variable name="lang-attr">
-      <xsl:choose>
-        <xsl:when test="($lang-scope/@xml:lang)[1]">
-          <xsl:value-of select="($lang-scope/@xml:lang)[1]"/>
-        </xsl:when>
-        <!-- If we haven't found a language, fall back to English: -->
-        <xsl:otherwise>en-us</xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:variable name="candidate.suse.header.body">
-      <xsl:call-template name="string.subst">
-        <xsl:with-param name="string" select="$include.ssi.body"/>
-        <xsl:with-param name="target" select="$placeholder.ssi.language"/>
-        <xsl:with-param name="replacement" select="$lang-attr"/>
-      </xsl:call-template>
+      <xsl:call-template name="get-lang-for-ssi" />
     </xsl:variable>
 
     <xsl:call-template name="user.preroot"/>
@@ -257,6 +244,13 @@
         <xsl:call-template name="body.attributes"/>
         <xsl:call-template name="outerelement.class.attribute"/>
         <xsl:if test="$include.suse.header">
+          <xsl:variable name="candidate.suse.header.body">
+            <xsl:call-template name="string.subst">
+              <xsl:with-param name="string" select="$include.ssi.body"/>
+              <xsl:with-param name="target" select="$placeholder.ssi.language"/>
+              <xsl:with-param name="replacement" select="$lang-attr"/>
+            </xsl:call-template>
+          </xsl:variable>
           <xsl:text>&#10;</xsl:text>
           <xsl:comment>#include virtual="<xsl:value-of select="$candidate.suse.header.body"/>"</xsl:comment>
           <xsl:text>&#10;</xsl:text>

--- a/suse2022-ns/xhtml/chunk-common.xsl
+++ b/suse2022-ns/xhtml/chunk-common.xsl
@@ -226,13 +226,27 @@
     <xsl:param name="nav.context"/>
     <xsl:param name="content"/>
 
-    <xsl:variable name="lang">
-      <xsl:apply-templates select="(ancestor-or-self::*/@xml:lang)[last()]" mode="html.lang.attribute"/>
+    <xsl:variable name="lang-scope" select="ancestor-or-self::*[@xml:lang][1]"/>
+    <xsl:variable name="lang-attr">
+      <xsl:choose>
+        <xsl:when test="($lang-scope/@xml:lang)[1]">
+          <xsl:value-of select="($lang-scope/@xml:lang)[1]"/>
+        </xsl:when>
+        <!-- If we haven't found a language, fall back to English: -->
+        <xsl:otherwise>en-us</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="candidate.suse.header.body">
+      <xsl:call-template name="string.subst">
+        <xsl:with-param name="string" select="$include.ssi.body"/>
+        <xsl:with-param name="target" select="$placeholder.ssi.language"/>
+        <xsl:with-param name="replacement" select="$lang-attr"/>
+      </xsl:call-template>
     </xsl:variable>
 
     <xsl:call-template name="user.preroot"/>
 
-    <html lang="{$lang}">
+    <html lang="{$lang-attr}">
       <xsl:call-template name="root.attributes"/>
       <xsl:call-template name="html.head">
         <xsl:with-param name="prev" select="$prev"/>
@@ -242,6 +256,11 @@
       <body>
         <xsl:call-template name="body.attributes"/>
         <xsl:call-template name="outerelement.class.attribute"/>
+        <xsl:if test="$include.suse.header">
+          <xsl:text>&#10;</xsl:text>
+          <xsl:comment>#include virtual="<xsl:value-of select="$candidate.suse.header.body"/>"</xsl:comment>
+          <xsl:text>&#10;</xsl:text>
+        </xsl:if>
         <xsl:call-template name="bypass">
           <xsl:with-param name="format" select="'chunk'"/>
         </xsl:call-template>

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -272,15 +272,33 @@
   </xsl:variable>
 
   <title><xsl:value-of select="$title"/></title>
-  <meta charset="UTF-8"/>
 
-  <xsl:if test="$include.suse.header = 0">
-  <meta name="viewport"
+  <xsl:choose>
+    <xsl:when test="$include.suse.header">
+      <xsl:variable name="candidate.suse.header.head">
+        <xsl:call-template name="string.subst">
+          <xsl:with-param name="string" select="$include.ssi.header" />
+          <xsl:with-param name="target" select="$placeholder.ssi.language" />
+          <xsl:with-param name="replacement">
+            <xsl:call-template name="get-lang-for-ssi" />
+          </xsl:with-param>
+        </xsl:call-template>
+      </xsl:variable>
+      <xsl:text>&#10;</xsl:text>
+      <xsl:comment>#include virtual="<xsl:value-of select="$candidate.suse.header.head" />"</xsl:comment>
+      <xsl:text>&#10;</xsl:text>
+    </xsl:when>
+    <xsl:otherwise>
+      <meta charset="UTF-8"/>
+      <meta name="viewport"
     content="width=device-width, initial-scale=1.0, user-scalable=yes"/>
-  </xsl:if>
+    </xsl:otherwise>
+  </xsl:choose>
 
   <xsl:if test="$html.base != ''">
-    <base href="{$html.base}"/>
+    <xsl:call-template name="head.content.base">
+      <xsl:with-param name="node" select="$node"/>
+    </xsl:call-template>
   </xsl:if>
 
   <!-- Insert links to CSS files or insert literal style elements -->
@@ -719,7 +737,9 @@
       <xsl:call-template name="string.subst">
         <xsl:with-param name="string" select="$include.ssi.body"/>
         <xsl:with-param name="target" select="$placeholder.ssi.language"/>
-        <xsl:with-param name="replacement" select="$lang-attr"/>
+        <xsl:with-param name="replacement">
+          <xsl:call-template name="get-lang-for-ssi"/>
+        </xsl:with-param>
       </xsl:call-template>
     </xsl:variable>
 
@@ -732,6 +752,22 @@
         <xsl:call-template name="system.head.content">
           <xsl:with-param name="node" select="$doc"/>
         </xsl:call-template>
+
+        <!--<xsl:if test="$include.suse.header">
+          <xsl:variable name="candidate.suse.header.head">
+            <xsl:call-template name="string.subst">
+              <xsl:with-param name="string" select="$include.ssi.header" />
+              <xsl:with-param name="target" select="$placeholder.ssi.language" />
+              <xsl:with-param name="replacement">
+                <xsl:call-template name="get-lang-for-ssi" />
+              </xsl:with-param>
+            </xsl:call-template>
+          </xsl:variable>
+          <xsl:text>&#10;</xsl:text>
+          <xsl:comment>#include virtual="<xsl:value-of select="$candidate.suse.header.head" />"</xsl:comment>
+          <xsl:text>&#10;</xsl:text>
+        </xsl:if>-->
+
         <xsl:call-template name="head.content">
           <xsl:with-param name="node" select="$doc"/>
         </xsl:call-template>
@@ -784,16 +820,6 @@
 
   <xsl:template name="user.head.content">
     <xsl:param name="node" select="."/>
-    <xsl:variable name="lang-attr">
-      <xsl:call-template name="get-lang-for-ssi"/>
-    </xsl:variable>
-    <xsl:variable name="candidate.suse.header.head">
-      <xsl:call-template name="string.subst">
-        <xsl:with-param name="string" select="$include.ssi.header"/>
-        <xsl:with-param name="target" select="$placeholder.ssi.language"/>
-        <xsl:with-param name="replacement" select="$lang-attr"/>
-      </xsl:call-template>
-    </xsl:variable>
 <!--
   <xsl:message>user.head.content
     lang-attr=<xsl:value-of select="$lang-attr"/>
@@ -806,16 +832,24 @@
   </xsl:message>
 -->
 
-    <xsl:text>&#10;</xsl:text>
+    <!--<xsl:text>&#10;</xsl:text>
     <xsl:choose>
       <xsl:when test="$include.suse.header">
+        <xsl:variable name="candidate.suse.header.head">
+          <xsl:call-template name="string.subst">
+            <xsl:with-param name="string" select="$include.ssi.header"/>
+            <xsl:with-param name="target" select="$placeholder.ssi.language"/>
+            <xsl:with-param name="replacement">
+              <xsl:call-template name="get-lang-for-ssi"/>
+            </xsl:with-param>
+          </xsl:call-template>
+        </xsl:variable>
         <xsl:text>&#10;</xsl:text>
         <xsl:comment>#include virtual="<xsl:value-of select="$candidate.suse.header.head"/>"</xsl:comment>
         <xsl:text>&#10;</xsl:text>
       </xsl:when>
-      <xsl:otherwise>
-      </xsl:otherwise>
-    </xsl:choose>
+      <xsl:otherwise/>
+    </xsl:choose>-->
 
     <xsl:if test="$build.for.web = 1">
       <script type="text/javascript">
@@ -945,18 +979,17 @@ if (window.location.protocol.toLowerCase() != 'file:') {
   </xsl:template>
 
   <xsl:template name="user.footer.content">
-    <xsl:variable name="lang-attr">
-      <xsl:call-template name="get-lang-for-ssi"/>
-    </xsl:variable>
     <xsl:variable name="candidate.suse.header.footer">
       <xsl:call-template name="string.subst">
         <xsl:with-param name="string" select="$include.ssi.footer"/>
         <xsl:with-param name="target" select="$placeholder.ssi.language"/>
-        <xsl:with-param name="replacement" select="$lang-attr"/>
+        <xsl:with-param name="replacement">
+          <xsl:call-template name="get-lang-for-ssi"/>
+        </xsl:with-param>
       </xsl:call-template>
     </xsl:variable>
 
-  <xsl:message>user.footer.content
+<!--  <xsl:message>user.footer.content
     node=<xsl:value-of select="local-name(.)"/>
     lang-attr=<xsl:value-of select="$lang-attr"/>
     include.ssi.footer=<xsl:value-of select="$include.ssi.footer"/>
@@ -966,13 +999,13 @@ if (window.location.protocol.toLowerCase() != 'file:') {
         <xsl:with-param name="target" select="$placeholder.ssi.language"/>
         <xsl:with-param name="replacement" select="$lang-attr"/>
       </xsl:call-template>
-  </xsl:message>
+  </xsl:message>-->
 
     <xsl:choose>
       <xsl:when test="$include.suse.header">
-        <xsl:comment>start:</xsl:comment>
+        <xsl:text>&#10;</xsl:text>
         <xsl:comment>#include virtual="<xsl:value-of select="$candidate.suse.header.footer"/>"</xsl:comment>
-        <xsl:comment>end</xsl:comment>
+        <xsl:text>&#10;</xsl:text>
       </xsl:when>
       <xsl:otherwise>
         <footer id="_footer">

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -746,7 +746,19 @@
     <xsl:call-template name="user.preroot"/>
     <xsl:call-template name="root.messages"/>
 
-    <html lang="{$lang-attr}">
+    <html>
+      <xsl:choose>
+        <xsl:when test="$rootid">
+          <xsl:call-template name="l10n.language">
+            <xsl:with-param name="target" select="key('id', $rootid)"/>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:call-template name="l10n.language">
+            <xsl:with-param name="target" select="/*[1]"/>
+          </xsl:call-template>
+        </xsl:otherwise>
+      </xsl:choose>
       <xsl:call-template name="root.attributes"/>
       <head>
         <xsl:call-template name="system.head.content">

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -765,21 +765,6 @@
           <xsl:with-param name="node" select="$doc"/>
         </xsl:call-template>
 
-        <!--<xsl:if test="$include.suse.header">
-          <xsl:variable name="candidate.suse.header.head">
-            <xsl:call-template name="string.subst">
-              <xsl:with-param name="string" select="$include.ssi.header" />
-              <xsl:with-param name="target" select="$placeholder.ssi.language" />
-              <xsl:with-param name="replacement">
-                <xsl:call-template name="get-lang-for-ssi" />
-              </xsl:with-param>
-            </xsl:call-template>
-          </xsl:variable>
-          <xsl:text>&#10;</xsl:text>
-          <xsl:comment>#include virtual="<xsl:value-of select="$candidate.suse.header.head" />"</xsl:comment>
-          <xsl:text>&#10;</xsl:text>
-        </xsl:if>-->
-
         <xsl:call-template name="head.content">
           <xsl:with-param name="node" select="$doc"/>
         </xsl:call-template>
@@ -832,36 +817,7 @@
 
   <xsl:template name="user.head.content">
     <xsl:param name="node" select="."/>
-<!--
-  <xsl:message>user.head.content
-    lang-attr=<xsl:value-of select="$lang-attr"/>
-    placeholder.ssi.language=<xsl:value-of select="$placeholder.ssi.language"/>
-    string=<xsl:call-template name="string.subst">
-        <xsl:with-param name="string" select="$include.ssi.header"/>
-        <xsl:with-param name="target" select="$placeholder.ssi.language"/>
-        <xsl:with-param name="replacement" select="'en-us'"/>
-      </xsl:call-template>
-  </xsl:message>
--->
 
-    <!--<xsl:text>&#10;</xsl:text>
-    <xsl:choose>
-      <xsl:when test="$include.suse.header">
-        <xsl:variable name="candidate.suse.header.head">
-          <xsl:call-template name="string.subst">
-            <xsl:with-param name="string" select="$include.ssi.header"/>
-            <xsl:with-param name="target" select="$placeholder.ssi.language"/>
-            <xsl:with-param name="replacement">
-              <xsl:call-template name="get-lang-for-ssi"/>
-            </xsl:with-param>
-          </xsl:call-template>
-        </xsl:variable>
-        <xsl:text>&#10;</xsl:text>
-        <xsl:comment>#include virtual="<xsl:value-of select="$candidate.suse.header.head"/>"</xsl:comment>
-        <xsl:text>&#10;</xsl:text>
-      </xsl:when>
-      <xsl:otherwise/>
-    </xsl:choose>-->
 
     <xsl:if test="$build.for.web = 1">
       <script type="text/javascript">
@@ -1000,18 +956,6 @@ if (window.location.protocol.toLowerCase() != 'file:') {
         </xsl:with-param>
       </xsl:call-template>
     </xsl:variable>
-
-<!--  <xsl:message>user.footer.content
-    node=<xsl:value-of select="local-name(.)"/>
-    lang-attr=<xsl:value-of select="$lang-attr"/>
-    include.ssi.footer=<xsl:value-of select="$include.ssi.footer"/>
-    placeholder.ssi.language=<xsl:value-of select="$placeholder.ssi.language"/>
-    string=<xsl:call-template name="string.subst">
-        <xsl:with-param name="string" select="$include.ssi.header"/>
-        <xsl:with-param name="target" select="$placeholder.ssi.language"/>
-        <xsl:with-param name="replacement" select="$lang-attr"/>
-      </xsl:call-template>
-  </xsl:message>-->
 
     <xsl:choose>
       <xsl:when test="$include.suse.header">

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -712,15 +712,8 @@
       <xsl:apply-imports/>
     </xsl:param>
     <xsl:variable name="doc" select="self::*"/>
-    <xsl:variable name="lang-scope" select="ancestor-or-self::*[@xml:lang][1]"/>
     <xsl:variable name="lang-attr">
-      <xsl:choose>
-        <xsl:when test="($lang-scope/@xml:lang)[1]">
-          <xsl:value-of select="($lang-scope/@xml:lang)[1]"/>
-        </xsl:when>
-        <!-- If we haven't found a language, fall back to English: -->
-        <xsl:otherwise>en-us</xsl:otherwise>
-      </xsl:choose>
+      <xsl:call-template name="get-lang-for-ssi"/>
     </xsl:variable>
     <xsl:variable name="candidate.suse.header.body">
       <xsl:call-template name="string.subst">
@@ -791,16 +784,8 @@
 
   <xsl:template name="user.head.content">
     <xsl:param name="node" select="."/>
-    <xsl:variable name="lang-scope"
-                  select="ancestor-or-self::*[@xml:lang][1]"/>
     <xsl:variable name="lang-attr">
-      <xsl:choose>
-        <xsl:when test="($lang-scope/@xml:lang)[1]">
-          <xsl:value-of select="($lang-scope/@xml:lang)[1]"/>
-        </xsl:when>
-        <!-- If we haven't found a language, fall back to English: -->
-        <xsl:otherwise>en-us</xsl:otherwise>
-      </xsl:choose>
+      <xsl:call-template name="get-lang-for-ssi"/>
     </xsl:variable>
     <xsl:variable name="candidate.suse.header.head">
       <xsl:call-template name="string.subst">
@@ -818,7 +803,8 @@
         <xsl:with-param name="target" select="$placeholder.ssi.language"/>
         <xsl:with-param name="replacement" select="'en-us'"/>
       </xsl:call-template>
-  </xsl:message>-->
+  </xsl:message>
+-->
 
     <xsl:text>&#10;</xsl:text>
     <xsl:choose>
@@ -938,10 +924,9 @@ if (window.location.protocol.toLowerCase() != 'file:') {
 
 
   <xsl:template name="user.header.content">
-    <xsl:variable name="lang-scope"
-                  select="ancestor-or-self::*[@xml:lang][1]"/>
-    <xsl:variable name="lang-attr"
-                  select="($lang-scope/@xml:lang)[1]"/>
+    <xsl:variable name="lang-attr">
+      <xsl:call-template name="get-lang-for-ssi"/>
+    </xsl:variable>
     <xsl:variable name="candidate.suse.header.body">
       <xsl:call-template name="string.subst">
         <xsl:with-param name="string" select="$include.ssi.body"/>
@@ -960,16 +945,8 @@ if (window.location.protocol.toLowerCase() != 'file:') {
   </xsl:template>
 
   <xsl:template name="user.footer.content">
-    <xsl:variable name="lang-scope"
-      select="ancestor-or-self::*[@xml:lang][1]"/>
     <xsl:variable name="lang-attr">
-      <xsl:choose>
-        <xsl:when test="($lang-scope/@xml:lang)[1]">
-          <xsl:value-of select="($lang-scope/@xml:lang)[1]"/>
-        </xsl:when>
-        <!-- If we haven't found a language, fall back to English: -->
-        <xsl:otherwise>en-us</xsl:otherwise>
-      </xsl:choose>
+      <xsl:call-template name="get-lang-for-ssi"/>
     </xsl:variable>
     <xsl:variable name="candidate.suse.header.footer">
       <xsl:call-template name="string.subst">
@@ -979,9 +956,23 @@ if (window.location.protocol.toLowerCase() != 'file:') {
       </xsl:call-template>
     </xsl:variable>
 
+  <xsl:message>user.footer.content
+    node=<xsl:value-of select="local-name(.)"/>
+    lang-attr=<xsl:value-of select="$lang-attr"/>
+    include.ssi.footer=<xsl:value-of select="$include.ssi.footer"/>
+    placeholder.ssi.language=<xsl:value-of select="$placeholder.ssi.language"/>
+    string=<xsl:call-template name="string.subst">
+        <xsl:with-param name="string" select="$include.ssi.header"/>
+        <xsl:with-param name="target" select="$placeholder.ssi.language"/>
+        <xsl:with-param name="replacement" select="$lang-attr"/>
+      </xsl:call-template>
+  </xsl:message>
+
     <xsl:choose>
       <xsl:when test="$include.suse.header">
+        <xsl:comment>start:</xsl:comment>
         <xsl:comment>#include virtual="<xsl:value-of select="$candidate.suse.header.footer"/>"</xsl:comment>
+        <xsl:comment>end</xsl:comment>
       </xsl:when>
       <xsl:otherwise>
         <footer id="_footer">

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -339,10 +339,6 @@ task before
   </xsl:param>
 
 
-  <!-- Include header/footer via Server-Side Includes (SSI)? -->
-  <xsl:param name="include.ssi.header" select="''"/>
-  <xsl:param name="include.ssi.footer" select="''"/>
-
   <!-- Generate a footer with SUSE-specific content? -->
   <xsl:param name="generate.footer" select="$suse.content"/>
 
@@ -443,4 +439,19 @@ task before
 
   <!-- Should the report bug link and edit source icons be included? 0=no, 1=yes-->
   <xsl:param name="title.icons" select="1"/>
+
+
+  <!-- Include header/footer via Server-Side Includes (SSI)? 0=no, 1=yes
+  -->
+  <xsl:param name="include.suse.header" select="0"/>
+
+  <!-- When include.suse.header is set to 1, these are the paths for the SSIs
+       to be added inside <head>, <body>, and <footer>.
+       Use "{{#language#}}" to insert the language
+  -->
+  <xsl:param name="include.ssi.header">/docserv/fragments/{{#language#}}/suse-head.fragment.html</xsl:param>
+  <xsl:param name="include.ssi.body">/docserv/fragments/{{#language#}}/suse-body.fragment.html</xsl:param>
+  <xsl:param name="include.ssi.footer">/docserv/fragments/{{#language#}}/suse-footer.fragment.html</xsl:param>
+
+  <xsl:variable name="placeholder.ssi.language">{{#language#}}</xsl:variable>
 </xsl:stylesheet>


### PR DESCRIPTION
This PR contains:

* Add SSI for `<head>`, `<body>`, and footer
* Add lang for `<html>` (both single and for chunked)
* Introduce `get-lang-for-ssi()` (`utility.xsl`). Rewrite "single" language (like `en`) into language and country (`en-us`).
* Introduce parameter `include.suse.header` (default `0`). Setting it to `1` creates the structure described below.

### Created structure

```html
<html lang="en">
  <head>
    <title>...</title>
    <!--#include virtual="/docserv/fragments/en-us/suse-head.fragment.html"-->
    ...
  </head>
  <body>
  <!--#include virtual="/docserv/fragments/en-us/suse-body.fragment.html"-->
   ...
   <main>...</main>
   <!--#include virtual="/docserv/fragments/en-us/suse-footer.fragment.html"-->
  </body>
</html>
```
