### PR TITLE
Handle abstract/para in article titlepage

### DIFF
--- a/suse2022-ns/xhtml/titlepage.templates.xsl
+++ b/suse2022-ns/xhtml/titlepage.templates.xsl
@@ -249,7 +249,13 @@
   </xsl:template>
 
   <xsl:template match="d:abstract" mode="article.titlepage.recto.auto.mode">
-    <xsl:apply-templates select="."/>
+    <xsl:apply-templates mode="article.titlepage.recto.auto.mode"/>
+  </xsl:template>
+
+  <xsl:template match="d:para" mode="article.titlepage.recto.auto.mode">
+    <p>
+      <xsl:apply-templates/>
+    </p>
   </xsl:template>
 
   <xsl:template name="article.titlepage.before.recto">


### PR DESCRIPTION
Add another template for d:para in mode="article.titlepage.recto.auto.mode" If you have more than one para in article, they appear in HTML as joined text (without a linebreak).

Found by @dariavladykina . Many thanks!