### PR TITLE
Fix #533: Let publication date appear after titles

### DIFF
--- a/suse2022-ns/xhtml/titlepage.templates.xsl
+++ b/suse2022-ns/xhtml/titlepage.templates.xsl
@@ -249,14 +249,9 @@
   </xsl:template>
 
   <xsl:template match="d:abstract" mode="article.titlepage.recto.auto.mode">
-    <xsl:apply-templates mode="article.titlepage.recto.auto.mode"/>
+    <xsl:apply-imports/>
   </xsl:template>
 
-  <xsl:template match="d:para" mode="article.titlepage.recto.auto.mode">
-    <p>
-      <xsl:apply-templates/>
-    </p>
-  </xsl:template>
 
   <xsl:template name="article.titlepage.before.recto">
     <xsl:call-template name="version.info.headline"/>
@@ -296,6 +291,8 @@
             </xsl:when>
         </xsl:choose>
 
+        <xsl:call-template name="date.and.revision"/>
+
         <!-- Legal notice removed from here, now positioned at the bottom of the page, see: division.xsl -->
         <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:abstract"/>
         <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:artheader/d:abstract"/>
@@ -316,7 +313,6 @@
         <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:editor"/>
         <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:editor"/>
 
-        <xsl:call-template name="date.and.revision"/>
         <xsl:call-template name="vcs.url"/>
 
         <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:copyright"/>


### PR DESCRIPTION
This is only useful for SmartDocs and other articles

Previously, the publication date was placed _after_ the abstract. However, if the abstract becomes long, the publication date is moved. Perhaps it is even moved ouside of the visiable area of the reader.

This fix improves readability so readers now right after reading the title when this article was published.

See the following example how it looks:

![Screenshot_20230302_140912](https://user-images.githubusercontent.com/1312925/222439446-8794d35a-121a-4c53-abcd-d598782ea90e.png)

