### PR TITLE
Prepare 2.89.0 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Mar 02 15:40:00 UTC 2022 - tomschr@users.noreply.github.com
+
+- Update 2.89.0
+  - Fix #535: Let formal titles in abstract appear
+  - Fix #533: Let publication date appear after titles
+  - Handle abstract/para in article titlepage (#532)
+
+-------------------------------------------------------------------
 Thu Dec 26 09:04:00 UTC 2022 - tomschr@users.noreply.github.com
 
 - Update 2.88.3


### PR DESCRIPTION
This PR contains the following additions:

* Fix #535: Let formal titles in abstract appear
* Fix #533: Let publication date appear after titles
* Handle abstract/para in article titlepage (#532)