### PR TITLE
Improve social media (Twitter OpenGraph)

### DIFF
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -252,27 +252,6 @@
       <xsl:with-param name="ellipsize.after" select="$socialmedia.title.length"/>
     </xsl:call-template>
   </xsl:variable>
-  <xsl:variable name="socialmedia.preview">
-    <xsl:choose>
-      <!-- We ignore:
-           * inlinemediaobjects, because they are likely very small
-           * SVGs, because they don't work (according to the Contentking) -->
-      <!-- We reimplement ends-with() https://stackoverflow.com/questions/40934644 -->
-      <xsl:when
-        test="(descendant::d:figure/descendant::d:imagedata/@fileref
-              |descendant::d:informalfigure/descendant::d:imagedata/@fileref)[not(
-               substring(translate(., 'SVG', 'svg'), string-length(.) - 5) = '.svg')][1]">
-        <xsl:value-of
-          select="concat($canonical-url-base, '/', $img.src.path,
-                  (descendant::d:figure/descendant::d:imagedata/@fileref
-                  |descendant::d:informalfigure/descendant::d:imagedata/@fileref)[not(
-                    substring(translate(., 'SVG', 'svg'), string-length(.) - 5) = '.svg')][1])"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="concat($canonical-url-base, '/', $socialmedia.preview.default)"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:variable>
   <xsl:variable name="metanodes" select="$node/ancestor-or-self::*/d:info/d:meta"/>
 
   <title><xsl:value-of select="$title"/></title>

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -415,7 +415,7 @@ task before
   <xsl:param name="onpage.teaser.length" select="300"/>
   <!-- <meta> description tags used for search results pages, roughly as
   recommended by the Contentking -->
-  <xsl:param name="search.title.length" select="55"/>
+  <xsl:param name="search.title.length" select="60"/>
   <xsl:param name="search.description.length" select="150"/>
   <!-- Open Graph (og:)/Twitter Cards tags used for social-media preview -->
   <xsl:param name="socialmedia.title.length" select="55"/>
@@ -431,8 +431,10 @@ task before
        stylesheets, having all result documents created with them associated
        with SUSE is suboptimal. -->
   <xsl:param name="twittercards.twitter.account" select="''"/>
-  <!-- Default social media preview image, if no other image is available on the page -->
-  <xsl:param name="socialmedia.preview.default">static/images/social-media-preview-default.png</xsl:param>
+  <!-- Default social media preview image, if no other image is available on the page
+  static/images/social-media-preview-default.png
+  -->
+  <xsl:param name="socialmedia.preview.default">document.jpg</xsl:param>
 
   <!-- The path for the report bug link and edit source icons -->
   <xsl:param name="title.icons.path">static/images/</xsl:param>


### PR DESCRIPTION
Part 2 of a series of changes for metadata:

* Use `meta[@name="social-descr"]` and fall back on other data
* If used fall back metadata, cut it to the maximum SEO length

See part 1: #542 