### PR TITLE
Missing xsl:attribute to create "lang" attribute

### DIFF
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -704,18 +704,20 @@
     <xsl:call-template name="root.messages"/>
 
     <html>
-      <xsl:choose>
-        <xsl:when test="$rootid">
-          <xsl:call-template name="l10n.language">
-            <xsl:with-param name="target" select="key('id', $rootid)"/>
-          </xsl:call-template>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:call-template name="l10n.language">
-            <xsl:with-param name="target" select="/*[1]"/>
-          </xsl:call-template>
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:attribute name="lang">
+        <xsl:choose>
+          <xsl:when test="$rootid">
+            <xsl:call-template name="l10n.language">
+              <xsl:with-param name="target" select="key('id', $rootid)"/>
+            </xsl:call-template>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:call-template name="l10n.language">
+              <xsl:with-param name="target" select="/*[1]"/>
+            </xsl:call-template>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
       <xsl:call-template name="root.attributes"/>
       <head>
         <xsl:call-template name="system.head.content">


### PR DESCRIPTION
After `<html>` you could see an "en" text. However, it should be `<html lang="en">` instead.

Found by @fsundermeyer, @GGayathri3, and @chabowski. Many thanks!