### PR TITLE
Implement Qualtrics rating

### DIFF
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -357,6 +357,20 @@
     <xsl:with-param name="node" select="$node"/>
   </xsl:call-template>
 
+  <xsl:if test="number($generate.qualtrics.div) != 0">
+    <xsl:comment>BEGIN QUALTRICS WEBSITE FEEDBACK SNIPPET</xsl:comment>
+<script type='text/javascript'><![CDATA[(function(){var g=function(e,h,f,g){
+this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
+this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};
+this.check=function(){var a=this.get(f);if(a)a=a.split(":");else if(100!=e)"v"==h&&(e=Math.random()>=e/100?0:100),a=[h,e,0],this.set(f,a.join(":"));else return!0;var c=a[1];if(100==c)return!0;switch(a[0]){case "v":return!1;case "r":return c=a[2]%Math.floor(100/c),a[2]++,this.set(f,a.join(":")),!c}return!0};
+this.go=function(){if(this.check()){var a=document.createElement("script");a.type="text/javascript";a.src=g;document.body&&document.body.appendChild(a)}};
+this.start=function(){var t=this;"complete"!==document.readyState?window.addEventListener?window.addEventListener("load",function(){t.go()},!1):window.attachEvent&&window.attachEvent("onload",function(){t.go()}):t.go()};};
+try{(new g(100,"r","QSI_S_ZN_8qZUmklKYbBqAYe","https://zn8qzumklkybbqaye-suselinux.siteintercept.qualtrics.com/SIE/?Q_ZID=ZN_8qZUmklKYbBqAYe")).start()}catch(i){}})();]]>
+</script><div id='ZN_8qZUmklKYbBqAYe'><xsl:comment>DO NOT REMOVE-CONTENTS PLACED HERE</xsl:comment></div>
+    <xsl:text>&#10;</xsl:text>
+    <xsl:comment>END WEBSITE FEEDBACK SNIPPET</xsl:comment>
+    <xsl:text>&#10;</xsl:text>
+  </xsl:if>
 </xsl:template>
 
 
@@ -577,6 +591,12 @@
     </xsl:if>
   </xsl:template>
 
+
+  <xsl:template name="qualtrics.rating">
+    <xsl:if test="number($generate.qualtrics.div) != 0 and  $qualtrics.id != ''">
+      <div id="{$qualtrics.id}"></div>
+    </xsl:if>
+  </xsl:template>
 
   <xsl:template name="generate.sourcelink">
     <xsl:param name="node" select="."/>
@@ -979,6 +999,7 @@ if (window.location.protocol.toLowerCase() != 'file:') {
 
       <xsl:call-template name="give.feedback"/>
       <xsl:call-template name="share.and.print"/>
+      <xsl:call-template name="qualtrics.rating"/>
 
       <xsl:text> </xsl:text>
     </aside>

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -462,4 +462,9 @@ task before
   <xsl:param name="generate.json-ld" select="0"/>
 
   <xsl:variable name="placeholder.ssi.language">{{#language#}}</xsl:variable>
+
+  <!-- The ID for the Qualtricks <div> -->
+  <xsl:param name="generate.qualtrics.div" select="0"/>
+  <xsl:param name="qualtrics.id">qualtrics_container</xsl:param>
+
 </xsl:stylesheet>


### PR DESCRIPTION
From the meeting with Asya, we need an empty `<div>` container with an id. This empty container will appear in the third column after the "Share this page" social media links.

Two parameter are introduced:

* `generate.qualtrics.div` (default `0`) When this parameter is set to 1, the empty `div` container is created.

* `qualtrics.id` (default `"qualtrics_container"`) The default id to reference in Qualtrics. Normally, you don't change this parameter.

Keep in mind, only when `$generate.qualtrics.div != 0` AND `$qualtrics.id != ''` are set that the empty `<div>` is generated. This avoids a `<div id="">` container with empty `id`.

Additionally, Qualtrics requires some JavaScript code in the header.

---

To enable the rating, use this command:

```
$ daps -v -d DC-file html --param generate.qualtrics.div=1
```

To use a different id than the default, use this command:

```
$ daps -v -d DC-file html --stringparam "qualtrics.id=my-own-id"
```

