### PR TITLE
Introduce qualtrics-feedback.js parameter & file

### DIFF
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -358,7 +358,13 @@
   </xsl:call-template>
 
   <xsl:if test="number($generate.qualtrics.div) != 0">
-    <xsl:comment>BEGIN QUALTRICS WEBSITE FEEDBACK SNIPPET</xsl:comment>
+    <xsl:choose>
+      <xsl:when test="$qualtrics-feedback.js != ''">
+        <xsl:copy-of select="document($qualtrics-feedback.js)/*/node()"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- TODO: This is just a fallback and can be removed at some point -->
+        <xsl:comment>BEGIN QUALTRICS WEBSITE FEEDBACK SNIPPET</xsl:comment>
 <script type='text/javascript'><![CDATA[(function(){var g=function(e,h,f,g){
 this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
 this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};
@@ -370,6 +376,8 @@ try{(new g(100,"r","QSI_S_ZN_8qZUmklKYbBqAYe","https://zn8qzumklkybbqaye-suselin
     <xsl:text>&#10;</xsl:text>
     <xsl:comment>END WEBSITE FEEDBACK SNIPPET</xsl:comment>
     <xsl:text>&#10;</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:if>
 </xsl:template>
 

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -466,5 +466,19 @@ task before
   <!-- The ID for the Qualtricks <div> -->
   <xsl:param name="generate.qualtrics.div" select="0"/>
   <xsl:param name="qualtrics.id">qualtrics_container</xsl:param>
+  <!-- The path to the Qualtrics JS file. By default, it's relative to the stylesheet.
+       The content should be (correct the syntax HTML comment):
+
+       <html xmlns="http://www.w3.org/1999/xhtml">
+          <!- -BEGIN QUALTRICS WEBSITE FEEDBACK SNIPPET- ->
+          <script type='text/javascript'><![CDATA[... add your content here ...]]></script>
+          <div id='ZN_8qZUmklKYbBqAYe'><!- -DO NOT REMOVE-CONTENTS PLACED HERE- -></div>
+          <!- -END WEBSITE FEEDBACK SNIPPET- ->
+       </html>
+
+       The root element is cut off (it can be any tagname, <html> is just an example).
+       Anything below <html> is copied, including HTML comments and the <script>.
+  -->
+  <xsl:param name="qualtrics-feedback.js">qualtrics-feedback.js</xsl:param>
 
 </xsl:stylesheet>

--- a/suse2022-ns/xhtml/qualtrics-feedback.js
+++ b/suse2022-ns/xhtml/qualtrics-feedback.js
@@ -1,0 +1,13 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<!--BEGIN QUALTRICS WEBSITE FEEDBACK SNIPPET-->
+<script type='text/javascript'><![CDATA[(function(){var g=function(e,h,f,g){
+this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
+this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};
+this.check=function(){var a=this.get(f);if(a)a=a.split(":");else if(100!=e)"v"==h&&(e=Math.random()>=e/100?0:100),a=[h,e,0],this.set(f,a.join(":"));else return!0;var c=a[1];if(100==c)return!0;switch(a[0]){case "v":return!1;case "r":return c=a[2]%Math.floor(100/c),a[2]++,this.set(f,a.join(":")),!c}return!0};
+this.go=function(){if(this.check()){var a=document.createElement("script");a.type="text/javascript";a.src=g;document.body&&document.body.appendChild(a)}};
+this.start=function(){var t=this;"complete"!==document.readyState?window.addEventListener?window.addEventListener("load",function(){t.go()},!1):window.attachEvent&&window.attachEvent("onload",function(){t.go()}):t.go()};};
+try{(new g(100,"r","QSI_S_ZN_8qZUmklKYbBqAYe","https://zn8qzumklkybbqaye-suselinux.siteintercept.qualtrics.com/SIE/?Q_ZID=ZN_8qZUmklKYbBqAYe")).start()}catch(i){}})();]]>
+</script>
+ <div id='ZN_8qZUmklKYbBqAYe'><!--DO NOT REMOVE-CONTENTS PLACED HERE--></div>
+<!--END WEBSITE FEEDBACK SNIPPET-->
+</html>


### PR DESCRIPTION
To make customization easier:

* Add `qualtrics-feedback.js` parameter
* Add a separate "qualtrics-feedback.js" file
* ATM, if `generate.qualtrics.div != 0 and qualtrics-feedback.js == ''`, we fallback to a hardcoded implementation.
  TODO: remove it once the file implementation is stable
* If the file needs to be customized, this should be the content:

   ```html
      <html xmlns="http://www.w3.org/1999/xhtml">
         <!--BEGIN QUALTRICS WEBSITE FEEDBACK SNIPPET-->
         <script type='text/javascript'><![CDATA[... add your content here ...]]></script>
         <div id='CHANGE_ID'><!--DO NOT REMOVE-CONTENTS PLACED HERE--></div>
         <!--END WEBSITE FEEDBACK SNIPPET-->
      </html>
   ```

Related to #551