### PR TITLE
Json ld finetune 1

### DIFF
--- a/suse2022-ns/xhtml/json-ld.xsl
+++ b/suse2022-ns/xhtml/json-ld.xsl
@@ -232,30 +232,30 @@
              TODO: check format. It must be in ISO format.
         -->
         <xsl:when test="$node/d:info/d:meta[@name='published']">
-          <xsl:value-of select="string($node/d:info/d:meta[@name='published'])"/>
+          <xsl:value-of select="normalize-space(string($node/d:info/d:meta[@name='published']))"/>
         </xsl:when>
         <xsl:when test="$node/d:info/d:pubdate">
-          <xsl:value-of select="string($node/d:info/d:pubdate)"/>
+          <xsl:value-of select="normalize-space(string($node/d:info/d:pubdate))"/>
         </xsl:when>
         <xsl:when test="$node/d:info/d:date">
-          <xsl:value-of select="string($node/d:info/d:pubdate)"/>
+          <xsl:value-of select="normalize-space(string($node/d:info/d:pubdate))"/>
         </xsl:when>
         <xsl:when test="$node/d:info/d:revhistory/d:revision[1]/d:date">
-          <xsl:value-of select="string($node/d:info/d:revhistory/d:revision[1]/d:date)"/>
+          <xsl:value-of select="normalize-space(string($node/d:info/d:revhistory/d:revision[1]/d:date))"/>
         </xsl:when>
       </xsl:choose>
     </xsl:variable>
 
     <xsl:choose>
       <xsl:when test="$date != ''">
-    "datePublished": "<xsl:value-of select="normalize-space($date)"/>",
+    "datePublished": "<xsl:value-of select="$date"/>",
       </xsl:when>
       <xsl:otherwise>
         <xsl:call-template name="log.message">
           <xsl:with-param name="level">warn</xsl:with-param>
           <xsl:with-param name="context-desc">JSON-LD</xsl:with-param>
           <xsl:with-param name="message">
-            <xsl:text>Could not create "datePublished" entry as no element was appropriate.</xsl:text>
+            <xsl:text>Could not create "datePublished" property as no element was appropriate.</xsl:text>
           </xsl:with-param>
         </xsl:call-template>
       </xsl:otherwise>

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -460,6 +460,11 @@ task before
 
   <!-- Should we generate a JSON-LD structure? 0=no, 1=yes -->
   <xsl:param name="generate.json-ld" select="0"/>
+  <xsl:param name="json-ld-fallback-author-name">SUSE documentation team</xsl:param>
+  <xsl:param name="json-ld-fallback-author-url">https://documentation.suse.com</xsl:param>
+  <xsl:param name="json-ld-fallback-author-type">Corporation</xsl:param>
+  <xsl:param name="json-ld-fallback-author-logo">https://www.suse.com/assets/img/suse-white-logo-green.svg</xsl:param>
+
 
   <xsl:variable name="placeholder.ssi.language">{{#language#}}</xsl:variable>
 </xsl:stylesheet>


### PR DESCRIPTION
This PR contains the following changes:

* Correct metadata
  * Rename `"abstract"` -> `"description"` and refactor code
  * Introduce `"sameAs"` property
  * Disable `json-ld-version` and `json-ld-keywords`
  * Use "Corporation" instead of "Organization" for default author and publisher

* JSON-LD: Rewrite `author` + `authorgroup` code
  * Simplify code and create a two set approach
  * If no (`author`/`editor`/`corpauthor`/`contributor`)s or `authorgroup` is
    found, fallback to a default corporation author
  * Add new parameters:
    - `json-ld-fallback-author-name`: The author's name
    - `json-ld-fallback-author-url`: the author's URL
    - `json-ld-fallback-author-type`: "Corporation" by default
      (but can also be a "Person")
    - `json-ld-fallback-author-logo`: the URL pointing to the logo