### PR TITLE
JSON-LD: Remove quotes in headlines & descriptions

### DIFF
--- a/suse2022-ns/xhtml/json-ld.xsl
+++ b/suse2022-ns/xhtml/json-ld.xsl
@@ -83,8 +83,8 @@
 
   <xsl:template name="json-ld-headline">
     <xsl:param name="node" select="."/>
-    <xsl:variable name="headline" select="($node/d:info/d:meta[@name='title'] | $node/d:info/d:title | $node/d:title)[last()]"/>
-    "headline": "<xsl:value-of select="normalize-space($headline)"/>",
+    <xsl:variable name="headline" select="normalize-space(($node/d:info/d:meta[@name='title'] | $node/d:info/d:title | $node/d:title)[last()])"/>
+    "headline": "<xsl:value-of select="translate($headline, '&quot;', '')"/>",
   </xsl:template>
 
   <xsl:template name="json-ld-description">
@@ -121,7 +121,7 @@
     </xsl:variable>
 
       <xsl:if test="$description != ''">
-    "description": "<xsl:value-of select="$description"/>",
+    "description": "<xsl:value-of select="translate($description, '&quot;', '')"/>",
       </xsl:if>
   </xsl:template>
 


### PR DESCRIPTION
## Problem

If a text contains "quotes", this text will create a syntax error for JSON. Either the quotes need to be masked or removed. I decided to remove them with translate().

First discovered for `/de-de/sles/15-SP1/html/SLES-all/cha-apache2.html`.


## Solution

This PR adds the XPath function `translate()` to remove and quotes. Although this is not entirely accurate, it's probably the easiest and fastest solution.
