### PR TITLE
Process <revhistory> in book & article title pages

### DIFF
--- a/source-assets/styles2022/sass/custom/content-title.sass
+++ b/source-assets/styles2022/sass/custom/content-title.sass
@@ -10,6 +10,15 @@ h6
 h1:has(.title-container)
   padding: 80px 0 80px
 
+.revhistory
+  margin-left: 2em
+  margin-right: 2em
+
+.titlepage-revhistory
+  margin-top: 1em
+  margin-bottom: 1em
+
+
 // FIXME: almost everything below needs a thorough cleanup!
 
 .article,

--- a/suse2022-ns/common/l10n/ar.xml
+++ b/suse2022-ns/common/l10n/ar.xml
@@ -249,6 +249,7 @@ translators apparently want those. - sknorr, 2016-09-30 -->
 
    <l:context name="title">
       <l:template name="part" text="الجزء&#160;%n&#160;%t"/>
+      <l:template name="revhistory" text="%t"/>
    </l:context>
 
    <l:context name="keycap">

--- a/suse2022-ns/common/l10n/cs.xml
+++ b/suse2022-ns/common/l10n/cs.xml
@@ -222,6 +222,7 @@
 
    <l:context name="title">
       <l:template name="part" text="Díl&#160;%n „%t“" />
+      <l:template name="revhistory" text="%t"/>
    </l:context>
 
 

--- a/suse2022-ns/common/l10n/da.xml
+++ b/suse2022-ns/common/l10n/da.xml
@@ -187,6 +187,7 @@
 
    <l:context name="title">
       <l:template name="part" text="Del&#160;%n&#160;%t"/>
+      <l:template name="revhistory" text="%t"/>
    </l:context>
 
 

--- a/suse2022-ns/common/l10n/de.xml
+++ b/suse2022-ns/common/l10n/de.xml
@@ -174,6 +174,10 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
+   <l:context name="title">
+      <l:template name="revhistory" text="%t"/>
+   </l:context>
+
    <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/>

--- a/suse2022-ns/common/l10n/en.xml
+++ b/suse2022-ns/common/l10n/en.xml
@@ -179,8 +179,8 @@
 
    <l:context name="title">
       <l:template name="part" text="Part&#160;%n&#160;%t"/>
+      <l:template name="revhistory" text="%t"/>
    </l:context>
-
 
    <l:context name="keycap">
       <l:template name="alt" text="Alt"/>

--- a/suse2022-ns/common/l10n/es.xml
+++ b/suse2022-ns/common/l10n/es.xml
@@ -195,6 +195,10 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
+   <l:context name="title">
+     <l:template name="revhistory" text="%t"/>
+   </l:context>
+
    <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/>

--- a/suse2022-ns/common/l10n/fi.xml
+++ b/suse2022-ns/common/l10n/fi.xml
@@ -184,6 +184,7 @@
 
    <l:context name="title">
       <l:template name="part" text="Osa&#160;%n&#160;%t"/>
+      <l:template name="revhistory" text="%t"/>
    </l:context>
 
    <l:context name="keycap">

--- a/suse2022-ns/common/l10n/fr.xml
+++ b/suse2022-ns/common/l10n/fr.xml
@@ -175,6 +175,10 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
+  <l:context name="title">
+    <l:template name="revhistory" text="%t"/>
+  </l:context>
+
    <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/>

--- a/suse2022-ns/common/l10n/hu.xml
+++ b/suse2022-ns/common/l10n/hu.xml
@@ -197,8 +197,8 @@
    <l:context name="title">
      <l:template name="part" text="%n&#160;%t&#160;r&#233;sz"/>
      <l:template name="part" style="title" text="%n.&#160;r&#233;sz %t"/>
+     <l:template name="revhistory" text="%t"/>
    </l:context>
-
 
    <l:context name="keycap">
       <l:template name="alt" text="Alt"/>

--- a/suse2022-ns/common/l10n/it.xml
+++ b/suse2022-ns/common/l10n/it.xml
@@ -189,6 +189,10 @@
       <l:template name="format" text="d.m.Y"/>
    </l:context>
 
+   <l:context name="title">
+     <l:template name="revhistory" text="%t"/>
+   </l:context>
+
    <l:context name="keycap">
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/>

--- a/suse2022-ns/common/l10n/ja.xml
+++ b/suse2022-ns/common/l10n/ja.xml
@@ -194,6 +194,10 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
+   <l:context name="title">
+      <l:template name="revhistory" text="%t"/>
+   </l:context>
+
    <l:context name="keycap"><!-- FIXME: What are the Japanese keycaps? -->
       <l:template name="alt" text="Alt"/>
       <l:template name="backspace" text="&lt;&#x2014;"/><!-- mdash -->

--- a/suse2022-ns/common/l10n/ko.xml
+++ b/suse2022-ns/common/l10n/ko.xml
@@ -131,6 +131,7 @@
     <l:context name="title-numbered">
      <l:template name="Part" text="%n&#48512; %t"/>
      <l:template name="part" text="%n&#48512; %t"/>
+     <l:template name="revhistory" text="%t"/>
    </l:context>
 
    <l:context name="xref-number-and-title">

--- a/suse2022-ns/common/l10n/lt_lt.xml
+++ b/suse2022-ns/common/l10n/lt_lt.xml
@@ -173,6 +173,7 @@
 
    <l:context name="title">
       <l:template name="part" text="%t&#160;%n&#160;dalis"/>
+      <l:template name="revhistory" text="%t"/>
    </l:context>
 
    <l:context name="keycap">

--- a/suse2022-ns/common/l10n/nl.xml
+++ b/suse2022-ns/common/l10n/nl.xml
@@ -206,6 +206,7 @@
 
    <l:context name="title">
       <l:template name="part" text="Onderdeel&#160;%n&#160;%t"/>
+      <l:template name="revhistory" text="%t"/>
    </l:context>
 
 

--- a/suse2022-ns/common/l10n/no.xml
+++ b/suse2022-ns/common/l10n/no.xml
@@ -172,6 +172,7 @@
 
    <l:context name="title">
       <l:template name="part" text="Del&#160;%n&#160;%t"/>
+      <l:template name="revhistory" text="%t"/>
    </l:context>
 
    <l:context name="msgset">

--- a/suse2022-ns/common/l10n/pl.xml
+++ b/suse2022-ns/common/l10n/pl.xml
@@ -178,6 +178,7 @@
 
    <l:context name="title">
       <l:template name="part" text="Cz&#x119;&#x15b;&#x107;&#160;%n&#160;%t"/>
+      <l:template name="revhistory" text="%t"/>
    </l:context>
 
    <l:context name="msgset">

--- a/suse2022-ns/common/l10n/pt_br.xml
+++ b/suse2022-ns/common/l10n/pt_br.xml
@@ -171,6 +171,7 @@
 
    <l:context name="title">
       <l:template name="part" text="Parte&#160;%n&#160;%t"/>
+      <l:template name="revhistory" text="%t"/>
    </l:context>
 
 

--- a/suse2022-ns/common/l10n/ru.xml
+++ b/suse2022-ns/common/l10n/ru.xml
@@ -171,6 +171,9 @@
       <l:template name="toc" text="%t"/>
    </l:context>
 
+   <l:context name="title">
+      <l:template name="revhistory" text="%t"/>
+   </l:context>
 
    <l:context name="msgset">
       <l:template name="alt" text="Alt"/>

--- a/suse2022-ns/common/l10n/sv.xml
+++ b/suse2022-ns/common/l10n/sv.xml
@@ -169,6 +169,7 @@
 
    <l:context name="title">
       <l:template name="part" text="Del&#160;%n&#160;%t"/>
+      <l:template name="revhistory" text="%t"/>
    </l:context>
 
    <l:context name="msgset">

--- a/suse2022-ns/common/l10n/zh_cn.xml
+++ b/suse2022-ns/common/l10n/zh_cn.xml
@@ -256,6 +256,7 @@
 
   <l:context name="title">
     <l:template name="chapter" text="&#31532;&#160;%n&#160;&#31456; %t"/>
+    <l:template name="revhistory" text="%t"/>
   </l:context>
 
   <l:context name="xref-number-and-title">

--- a/suse2022-ns/common/l10n/zh_tw.xml
+++ b/suse2022-ns/common/l10n/zh_tw.xml
@@ -86,6 +86,7 @@
 
   <l:context name="title">
     <l:template name="part" text="%n. %t"/>
+    <l:template name="revhistory" text="%t"/>
   </l:context>
 
   <l:context name="title-numbered">

--- a/suse2022-ns/common/titles.xsl
+++ b/suse2022-ns/common/titles.xsl
@@ -45,6 +45,19 @@
 </xsl:template>
 
 
+<xsl:template match="d:revhistory" mode="title.markup">
+    <xsl:choose>
+      <xsl:when test="d:title | d:info/d:title">
+        <xsl:apply-templates mode="title.markup"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="gentext">
+          <xsl:with-param name="key" select="'RevHistory'" />
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!--
    Temporary fix for version 1.78.1:
    See upstream revision 9820. Remove this snippet, if there is a newer

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -1983,6 +1983,14 @@ h6 {
 h1:has(.title-container) {
   padding: 80px 0 80px; }
 
+.revhistory {
+  margin-left: 2em;
+  margin-right: 2em; }
+
+.titlepage-revhistory {
+  margin-top: 1em;
+  margin-bottom: 1em; }
+
 .article .title,
 .book .title,
 .set .title {

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -2246,6 +2246,14 @@ h6 {
 h1:has(.title-container) {
   padding: 80px 0 80px; }
 
+.revhistory {
+  margin-left: 2em;
+  margin-right: 2em; }
+
+.titlepage-revhistory {
+  margin-top: 1em;
+  margin-bottom: 1em; }
+
 .article .title,
 .book .title,
 .set .title {

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -719,25 +719,25 @@
         </xsl:with-param>
       </xsl:call-template>
     </xsl:variable>
+    <xsl:variable name="candidate.lang">
+      <xsl:choose>
+        <xsl:when test="$rootid">
+          <xsl:call-template name="l10n.language">
+            <xsl:with-param name="target" select="key('id', $rootid)"/>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:call-template name="l10n.language">
+            <xsl:with-param name="target" select="/*[1]"/>
+          </xsl:call-template>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
 
     <xsl:call-template name="user.preroot"/>
     <xsl:call-template name="root.messages"/>
 
-    <html>
-      <xsl:attribute name="lang">
-        <xsl:choose>
-          <xsl:when test="$rootid">
-            <xsl:call-template name="l10n.language">
-              <xsl:with-param name="target" select="key('id', $rootid)"/>
-            </xsl:call-template>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:call-template name="l10n.language">
-              <xsl:with-param name="target" select="/*[1]"/>
-            </xsl:call-template>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:attribute>
+    <html lang="{$candidate.lang}" xml:lang="{$candidate.lang}">
       <xsl:call-template name="root.attributes"/>
       <head>
         <xsl:call-template name="system.head.content">

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -489,4 +489,22 @@ task before
   -->
   <xsl:param name="qualtrics-feedback.js">static/js/qualtrics-feedback.js</xsl:param>
 
+  <!-- Limit the revhistory list to X entries
+       If it's empty, display all
+  -->
+  <xsl:param name="revision.limit"/>
+
+  <!-- In case there is not revhistory/title, should the article/book title be included
+       after the default "Revision History" string?
+  -->
+  <xsl:param name="revision.add.div.title" select="1"/>
+
+  <!--
+    $generate.revhistory = enable or disable revhistory generation
+    valid values: 0 or 1
+  -->
+  <xsl:param name="generate.revhistory" select="1"/>
+
+  <!-- Generates a separate file -->
+  <xsl:param name="generate.revhistory.link" select="1"/>
 </xsl:stylesheet>

--- a/suse2022-ns/xhtml/titlepage.templates.xsl
+++ b/suse2022-ns/xhtml/titlepage.templates.xsl
@@ -233,6 +233,8 @@
 
   <!-- ===================================================== -->
   <!-- article titlepage templates -->
+
+
   <xsl:template match="d:authorgroup" mode="article.titlepage.recto.auto.mode">
     <xsl:call-template name="add.authorgroup"/>
   </xsl:template>
@@ -326,6 +328,10 @@
         <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:articleinfo/d:copyright"/>
         <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:artheader/d:copyright"/>
         <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:copyright"/>
+
+        <xsl:if test="number($generate.revhistory) = 1">
+          <xsl:apply-templates mode="article.titlepage.recto.auto.mode" select="d:info/d:revhistory"/>
+        </xsl:if>
   </xsl:template>
 
   <xsl:template name="article.titlepage.separator">
@@ -387,10 +393,12 @@
   <xsl:apply-templates mode="set.titlepage.recto.auto.mode" select="d:info/d:pubdate"/>
   <xsl:apply-templates mode="set.titlepage.recto.auto.mode" select="d:setinfo/d:revision"/>
   <xsl:apply-templates mode="set.titlepage.recto.auto.mode" select="d:info/d:revision"/>
-  <xsl:apply-templates mode="set.titlepage.recto.auto.mode" select="d:setinfo/d:revhistory"/>
-  <xsl:apply-templates mode="set.titlepage.recto.auto.mode" select="d:info/d:revhistory"/>
   <xsl:apply-templates mode="set.titlepage.recto.auto.mode" select="d:setinfo/d:abstract"/>
   <xsl:apply-templates mode="set.titlepage.recto.auto.mode" select="d:info/d:abstract"/>
+
+  <xsl:if test="number($generate.revhistory) = 1">
+    <xsl:apply-templates mode="set.titlepage.recto.auto.mode" select="d:info/d:revhistory"/>
+  </xsl:if>
 </xsl:template>
   <!-- ===================================================== -->
   <!-- book titlepage templates -->
@@ -431,6 +439,10 @@
         <!-- Legal notice removed from here, now positioned at the bottom of the page, see: division.xsl -->
         <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:bookinfo/d:abstract"/>
         <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:abstract"/>
+
+        <xsl:if test="number($generate.revhistory) = 1">
+          <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:revhistory"/>
+        </xsl:if>
 
         <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:bookinfo/d:corpauthor"/>
         <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="d:info/d:corpauthor"/>

--- a/suse2022-ns/xhtml/titlepage.xsl
+++ b/suse2022-ns/xhtml/titlepage.xsl
@@ -10,11 +10,13 @@
    Copyright:   2012, Stefan Knorr
 
 -->
-<xsl:stylesheet exclude-result-prefixes="d"
-                 version="1.0"
+<xsl:stylesheet version="1.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:d="http://docbook.org/ns/docbook"
-  xmlns="http://www.w3.org/1999/xhtml">
+  xmlns:exsl="http://exslt.org/common"
+  xmlns="http://www.w3.org/1999/xhtml"
+  exclude-result-prefixes="exsl d"
+  >
 
 
 <xsl:template match="d:book/d:title|d:article/d:title|d:set/d:title" mode="titlepage.mode">
@@ -61,6 +63,174 @@
   </h1>
   <xsl:call-template name="generate.title.icons"/>
   </div>
+</xsl:template>
+
+<!-- ============================================================== -->
+<!-- revhistory handling -->
+<xsl:template match="d:revhistory" mode="titlepage.mode">
+    <xsl:variable name="revhistory.text">
+      <xsl:call-template name="gentext">
+        <xsl:with-param name="key" select="'RevHistory'" />
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="empty.title">
+      <d:title>
+        <xsl:value-of select="$revhistory.text"/>
+        <xsl:if test="$revision.add.div.title">
+          <xsl:text>: </xsl:text>
+          <xsl:choose>
+            <xsl:when test="$rootid">
+              <xsl:value-of
+                select="(key('id', $rootid)/d:title | key('id', $rootid)/d:info/d:title)[1]"
+               />
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="(/*/d:title | /*/d:info/d:title)[1]" />
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:if>
+      </d:title>
+    </xsl:variable>
+    <xsl:variable name="title">
+      <xsl:choose>
+        <xsl:when test="d:title | d:info/d:title">
+          <xsl:apply-templates select="(d:title | d:info/d:title)[1]"
+            mode="titlepage.mode" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates select="exsl:node-set($empty.title)/*"
+            mode="titlepage.mode" />
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
+    <xsl:variable name="contents">
+      <div>
+        <xsl:apply-templates select="." mode="common.html.attributes" />
+        <xsl:call-template name="id.attribute" />
+
+        <xsl:copy-of select="$title" />
+        <xsl:choose>
+          <xsl:when test="$revision.limit != '' and number($revision.limit) > 2">
+            <xsl:apply-templates select="d:revision[position() &lt;= $revision.limit]" mode="titlepage.mode" >
+              <xsl:sort order="descending" select="number(translate(d:date, '-', ''))"/>
+            </xsl:apply-templates>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates select="d:revision" mode="titlepage.mode" >
+              <xsl:sort order="descending" select="number(translate(d:date, '-', ''))"/>
+            </xsl:apply-templates>
+          </xsl:otherwise>
+        </xsl:choose>
+      </div>
+    </xsl:variable>
+
+    <xsl:choose>
+      <xsl:when test="$generate.revhistory.link != 0">
+
+        <!-- Compute name of revhistory file -->
+        <xsl:variable name="file">
+          <xsl:call-template name="ln.or.rh.filename">
+            <xsl:with-param name="is.ln" select="false()" />
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:variable name="filename">
+          <xsl:call-template name="make-relative-filename">
+            <xsl:with-param name="base.dir" select="$chunk.base.dir" />
+            <xsl:with-param name="base.name" select="$file" />
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:variable name="candidate.lang">
+          <xsl:choose>
+            <xsl:when test="$rootid">
+              <xsl:call-template name="l10n.language">
+                <xsl:with-param name="target" select="key('id', $rootid)"/>
+              </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:call-template name="l10n.language">
+                <xsl:with-param name="target" select="/*[1]"/>
+              </xsl:call-template>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+
+        <!-- Create the link to the revhistory page -->
+        <div class="titlepage-revhistory">
+          <a aria-label="{$revhistory.text}" hreflang="{$candidate.lang}"
+             href="{$file}" target="_blank"><xsl:copy-of select="string($title)" /></a>
+        </div>
+
+        <xsl:call-template name="write.chunk">
+          <xsl:with-param name="filename" select="$filename" />
+          <xsl:with-param name="quiet" select="$chunk.quietly" />
+          <xsl:with-param name="content">
+            <xsl:call-template name="user.preroot" />
+            <html lang="{$candidate.lang}" xml:lang="{$candidate.lang}">
+              <head>
+                <xsl:call-template name="system.head.content" />
+                <xsl:call-template name="head.content">
+                  <xsl:with-param name="title">
+                    <xsl:value-of select="$title" />
+                    <xsl:if test="../../d:title">
+                      <xsl:value-of select="concat(' (', ../../d:title, ')')" />
+                    </xsl:if>
+                  </xsl:with-param>
+                </xsl:call-template>
+                <xsl:call-template name="user.head.content" />
+              </head>
+              <body>
+                <xsl:call-template name="body.attributes" />
+                <xsl:copy-of select="$contents" />
+              </body>
+            </html>
+            <xsl:text>
+</xsl:text>
+          </xsl:with-param>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy-of select="$contents" />
+      </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+
+<xsl:template match="d:revhistory/d:revision" mode="titlepage.mode">
+  <xsl:variable name="revnumber" select="d:revnumber"/>
+  <xsl:variable name="revauthor" select="d:authorinitials|d:author"/>
+  <xsl:variable name="revremark" select="d:revremark|d:revdescription"/>
+
+  <section>
+    <xsl:apply-templates select="." mode="common.html.attributes"/>
+    <xsl:call-template name="id.attribute" />
+
+    <h2>
+      <span class="revision date"><xsl:apply-templates select="d:date" mode="titlepage.mode"/></span>
+      <xsl:if test="$revnumber">
+        <span class="revision sep"> | </span>
+          <span>
+            <xsl:apply-templates select="$revnumber[1]" mode="titlepage.mode" />
+          </span>
+      </xsl:if>
+    </h2>
+
+    <xsl:if test="$revauthor">
+      <p>
+        <xsl:for-each select="$revauthor">
+            <xsl:apply-templates select="." mode="titlepage.mode"/>
+            <xsl:if test="position() != last()">
+              <xsl:text>, </xsl:text>
+            </xsl:if>
+          </xsl:for-each>
+      </p>
+    </xsl:if>
+
+    <xsl:apply-templates select="*[not(self::d:date or
+                                       self::d:revnumber or
+                                       self::d:author or
+                                       self::d:authorinitials)]" mode="titlepage.mode"/>
+  </section>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
This PR fixes #577 and contains the following changes:

* [x] Integrate <revhistory> in title page
* [x] Set `generate.revhistory.link=1`
* [x] Introduce new parameter `revision.limit`
* [x] Introduce new parameters `revhistory.number`
* [x] Sort revision entries by date
* [x] Style the revhistory link of the title page
* [x] Style the separate revhistory file
