### PR TITLE
Fix #517: Process substeps/@performance='optional'

### DIFF
--- a/suse2022-ns/fo/lists.xsl
+++ b/suse2022-ns/fo/lists.xsl
@@ -325,7 +325,7 @@
                                    local-name()='simpara' or
                                    local-name()='formalpara']"
               priority="2">
-
+  <xsl:variable name="perf" select="(../@performance|../../@performance)[last()]"/>
   <fo:block xsl:use-attribute-sets="para.properties">
     <xsl:call-template name="no-break-after-colon"/>
 
@@ -335,7 +335,7 @@
         <xsl:with-param name="arch-value" select="@arch"/>
       </xsl:call-template>
     </xsl:if>
-    <xsl:if test="(self::d:para or self::d:simpara) and ../@performance='optional'">
+    <xsl:if test="(self::d:para or self::d:simpara) and $perf='optional'">
       <fo:inline color="&mid-gray;" xsl:use-attribute-sets="italicized">
         <xsl:call-template name="gentext">
           <xsl:with-param name="key" select="'step.optional'"/>

--- a/suse2022-ns/xhtml/lists.xsl
+++ b/suse2022-ns/xhtml/lists.xsl
@@ -112,6 +112,7 @@
   </xsl:template>
 
   <xsl:template match="d:step/*[1][local-name()='para' or local-name()='simpara']">
+   <xsl:variable name="perf" select="(../@performance|../../@performance)[last()]"/>
    <xsl:call-template name="paragraph">
      <xsl:with-param name="class">
        <xsl:if test="@role and $para.propagates.style != 0">
@@ -125,7 +126,7 @@
          </xsl:call-template>
        </xsl:if>
        <xsl:call-template name="anchor"/>
-       <xsl:if test="../@performance='optional'">
+       <xsl:if test="$perf='optional'">
          <span class="step-optional">
            <xsl:call-template name="gentext">
              <xsl:with-param name="key" select="'step.optional'"/>
@@ -137,6 +138,7 @@
      </xsl:with-param>
    </xsl:call-template>
   </xsl:template>
+
 
 <xsl:template match="d:listitem/d:simpara" priority="10">
   <!-- Unlike the original DocBook stylesheets, if a listitem contains only a


### PR DESCRIPTION
If you have the following structure:

```xml
 <step>
   <para>Third step. The following substeps are optional (except one):</para>
   <substeps performance="optional">
     <step>
       <para>First substep</para>
     </step>
     <step>
       <para>Second substep</para>
     </step>
     <step performance="required">
       <para>Required third step</para>
     </step>
   </substeps>
 </step>
```

It marks all `substeps` as optional except the third one. See example from HTML (similar for PDF):

![Screenshot_20231018_211541](https://github.com/openSUSE/suse-xsl/assets/1312925/c16d0383-ac39-4398-97b7-f106c40629a1)

