### PR TITLE
Set glossary.sort=1 to sort glossaries

### DIFF
--- a/suse2022-ns/fo/param.xsl
+++ b/suse2022-ns/fo/param.xsl
@@ -112,6 +112,8 @@ set       toc,title
 <!-- 16. Glossary =============================================== -->
 <xsl:param name="glossary.as.blocks" select="1"/>
 <xsl:param name="glosslist.as.blocks" select="1"/>
+<xsl:param name="glossary.sort" select="1"/>
+
 
 <!-- 17. Miscellaneous ========================================== -->
 <xsl:param name="bookmarks.collapse" select="0"/>

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -189,6 +189,7 @@ set       toc,title
 <!-- 16. Bibliography =========================================== -->
 
 <!-- 17. Glossary =============================================== -->
+<xsl:param name="glossary.sort" select="1"/>
 
 <!-- 18. Miscellaneous ========================================== -->
   <xsl:param name="menuchoice.separator" select="'&#xa0;›&#xa0;'"/>


### PR DESCRIPTION
Through discussion with Daria and Julia and to improve the sorting order for translations, turning on sorting glossaries and glosslists.