### PR TITLE
Remove "compact" output in admons

### DIFF
--- a/suse2022-ns/fo/admon.xsl
+++ b/suse2022-ns/fo/admon.xsl
@@ -102,7 +102,6 @@
   <xsl:call-template name="admon.symbol.color"/>
  </xsl:variable>
  <fo:block xsl:use-attribute-sets="dark-green">
-  <xsl:value-of select="@role"/>
   <xsl:apply-templates select="." mode="object.title.markup">
    <xsl:with-param name="allow-anchors" select="1"/>
   </xsl:apply-templates>


### PR DESCRIPTION
This PR removes the "compact" word inside an admon title. The result looks like:

![Screenshot_20231121_142553](https://github.com/openSUSE/suse-xsl/assets/1312925/4cad482c-6455-4730-a997-84a42b9c6e49)

This was the built from the old stylesheets:

![Screenshot_20231121_142840](https://github.com/openSUSE/suse-xsl/assets/1312925/761c5033-239d-4062-89ad-a2e9c43d0b3c)

