### PR TITLE
Fix #596: Correct runinhead.default.title.end.punct

### DIFF
--- a/suse2022-ns/common/l10n/ar.xml
+++ b/suse2022-ns/common/l10n/ar.xml
@@ -26,7 +26,7 @@ translators apparently want those. - sknorr, 2016-09-30 -->
    <l:gentext key="showcontentsoverview" text="ﻉﺮﺿ ﺎﻠﻤﺤﺗﻮﻳﺎﺗ" />
    <l:gentext key="find" text="ﺐﺤﺛ" />
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="التنقل"/>
    <l:gentext key="moredocuments" text="المزيد من المستندات"/>

--- a/suse2022-ns/common/l10n/cs.xml
+++ b/suse2022-ns/common/l10n/cs.xml
@@ -23,7 +23,7 @@
    <l:gentext key="showcontentsoverview" text="Zobrazit obsah"/>
    <l:gentext key="find" text="Najít"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navigace"/>
    <l:gentext key="moredocuments" text="Více dokumentů"/>

--- a/suse2022-ns/common/l10n/da.xml
+++ b/suse2022-ns/common/l10n/da.xml
@@ -26,7 +26,7 @@
    <l:gentext key="showcontentsoverview" text="Vis indhold"/>
    <l:gentext key="find" text="Find"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navigation"/>
    <l:gentext key="moredocuments" text="Flere dokumenter"/>

--- a/suse2022-ns/common/l10n/de.xml
+++ b/suse2022-ns/common/l10n/de.xml
@@ -25,7 +25,7 @@
    <l:gentext key="showcontentsoverview" text="Inhalt anzeigen"/>
    <l:gentext key="find" text="Suchen"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+  <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navigation" />
    <l:gentext key="moredocuments" text="Weitere Dokumente" />

--- a/suse2022-ns/common/l10n/en.xml
+++ b/suse2022-ns/common/l10n/en.xml
@@ -25,7 +25,7 @@
    <l:gentext key="showcontentsoverview" text="Show Contents"/>
    <l:gentext key="find" text="Find"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+  <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navigation"/>
    <l:gentext key="moredocuments" text="More documents"/>

--- a/suse2022-ns/common/l10n/es.xml
+++ b/suse2022-ns/common/l10n/es.xml
@@ -29,7 +29,7 @@
    <l:gentext key="showcontentsoverview" text="Mostrar contenido"/>
    <l:gentext key="find" text="Buscar"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navegación"/>
    <l:gentext key="moredocuments" text="Más documentos"/>

--- a/suse2022-ns/common/l10n/fi.xml
+++ b/suse2022-ns/common/l10n/fi.xml
@@ -24,7 +24,7 @@
    <l:gentext key="showcontentsoverview" text="Näytä sisältö"/>
    <l:gentext key="find" text="Etsi"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Siirtyminen"/>
    <l:gentext key="moredocuments" text="Lisää asiakirjoja"/>

--- a/suse2022-ns/common/l10n/fr.xml
+++ b/suse2022-ns/common/l10n/fr.xml
@@ -28,7 +28,7 @@
    <l:gentext key="showcontentsoverview" text="Afficher la table des matières" />
    <l:gentext key="find" text="Rechercher" />
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navigation" />
    <l:gentext key="moredocuments" text="Plus de documents" />

--- a/suse2022-ns/common/l10n/hu.xml
+++ b/suse2022-ns/common/l10n/hu.xml
@@ -30,7 +30,7 @@
    <l:gentext key="showcontentsoverview" text="Tartalom megjelenítése"/>
    <l:gentext key="find" text="Keresés"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navigáció" />
    <l:gentext key="moredocuments" text="Több dokumentum" />

--- a/suse2022-ns/common/l10n/it.xml
+++ b/suse2022-ns/common/l10n/it.xml
@@ -26,7 +26,7 @@
    <l:gentext key="showcontentsoverview" text="Mostra contenuto"/>
    <l:gentext key="find" text="Trova"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navigazione"/>
    <l:gentext key="moredocuments" text="Altri documenti" />

--- a/suse2022-ns/common/l10n/ja.xml
+++ b/suse2022-ns/common/l10n/ja.xml
@@ -25,7 +25,7 @@
    <l:gentext key="showcontentsoverview" text="目次を表示" />
    <l:gentext key="find" text="検索"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="." />
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;" />
 
    <l:gentext key="navigation" text="ナビゲーション"/>
    <l:gentext key="moredocuments" text="その他のドキュメント" />

--- a/suse2022-ns/common/l10n/ko.xml
+++ b/suse2022-ns/common/l10n/ko.xml
@@ -28,7 +28,7 @@
    <l:gentext key="showcontentsoverview" text="목차 표시"/>
    <l:gentext key="find" text="찾기"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="탐색"/>
    <l:gentext key="moredocuments" text="문서 더 보기" />

--- a/suse2022-ns/common/l10n/lt_lt.xml
+++ b/suse2022-ns/common/l10n/lt_lt.xml
@@ -25,7 +25,7 @@
    <l:gentext key="showcontentsoverview" text="Rodyti turinį"/>
    <l:gentext key="find" text="Rasti"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Naršymas"/>
    <l:gentext key="moredocuments" text="More documents"/>

--- a/suse2022-ns/common/l10n/nl.xml
+++ b/suse2022-ns/common/l10n/nl.xml
@@ -28,7 +28,7 @@
    <l:gentext key="showcontentsoverview" text="Inhoud weergeven"/>
    <l:gentext key="find" text="Zoeken"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navigatie"/>
    <l:gentext key="moredocuments" text="More documents"/>

--- a/suse2022-ns/common/l10n/no.xml
+++ b/suse2022-ns/common/l10n/no.xml
@@ -24,7 +24,7 @@
    <l:gentext key="showcontentsoverview" text="Vis innhold"/>
    <l:gentext key="find" text="Søk"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navigasjon"/>
    <l:gentext key="moredocuments" text="More documents"/>

--- a/suse2022-ns/common/l10n/pl.xml
+++ b/suse2022-ns/common/l10n/pl.xml
@@ -24,7 +24,7 @@
    <l:gentext key="showcontentsoverview" text="Pokaż treść" />
    <l:gentext key="find" text="Znajdź"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Nawigacja"/>
    <l:gentext key="moredocuments" text="Więcej dokumentów" />

--- a/suse2022-ns/common/l10n/pt_br.xml
+++ b/suse2022-ns/common/l10n/pt_br.xml
@@ -25,7 +25,7 @@
    <l:gentext key="showcontentsoverview" text="Mostrar Conteúdo"/>
    <l:gentext key="find" text="Encontrar" />
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navegação"/>
    <l:gentext key="moredocuments" text="Mais documentos" />

--- a/suse2022-ns/common/l10n/ru.xml
+++ b/suse2022-ns/common/l10n/ru.xml
@@ -24,7 +24,7 @@
    <l:gentext key="showcontentsoverview" text="Показать содержание"/>
    <l:gentext key="find" text="Поиск" />
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Навигация"/>
    <l:gentext key="moredocuments" text="Еще документы" />

--- a/suse2022-ns/common/l10n/sv.xml
+++ b/suse2022-ns/common/l10n/sv.xml
@@ -32,7 +32,7 @@
    <l:gentext key="showcontentsoverview" text="Visa innehåll"/>
    <l:gentext key="find" text="Hitta"/>
 
-   <l:gentext key="runinhead.default.title.end.punct" text="."/>
+   <l:gentext key="runinhead.default.title.end.punct" text=".&#x00a0;"/>
 
    <l:gentext key="navigation" text="Navigering"/>
    <l:gentext key="sharethispage" text="Dela den här sidan"/>

--- a/suse2022-ns/common/l10n/zh_cn.xml
+++ b/suse2022-ns/common/l10n/zh_cn.xml
@@ -25,7 +25,7 @@
   <l:gentext key="showcontentsoverview" text="显示目录" />
   <l:gentext key="find" text="查找" />
 
-  <l:gentext key="runinhead.default.title.end.punct" text="." />
+  <l:gentext key="runinhead.default.title.end.punct" text="&#xff1a;" />
 
   <l:gentext key="navigation" text="导航" />
   <l:gentext key="moredocuments" text="更多文档" />

--- a/suse2022-ns/fo/block.xsl
+++ b/suse2022-ns/fo/block.xsl
@@ -88,15 +88,16 @@
 </xsl:template>
 
 <xsl:template match="d:formalpara/d:title|d:formalpara/d:info/d:title">
-  <xsl:variable name="title-str">
+  <xsl:variable name="titlestr">
     <xsl:apply-templates/>
   </xsl:variable>
+  <xsl:variable name="ns-titlestr" select="normalize-space($titlestr)"/>
   <!-- Logic: If there is already a &punctuation; character at the end, we don't
        need to add another one, $last-char allows us to check. -->
   <xsl:variable name="last-char-candidate">
     <xsl:choose>
-      <xsl:when test="$title-str != ''">
-        <xsl:value-of select="substring($title-str,string-length($title-str),1)"/>
+      <xsl:when test="$titlestr != ''">
+        <xsl:value-of select="substring($ns-titlestr, string-length($ns-titlestr),1)"/>
       </xsl:when>
       <xsl:otherwise>FAIL</xsl:otherwise>
     </xsl:choose>
@@ -105,18 +106,18 @@
     <xsl:value-of select="translate($last-char-candidate, '&punctuation;', '')"/>
   </xsl:variable>
 
-  <xsl:if test="$title-str != ''">
+  <xsl:if test="$ns-titlestr != ''">
     <fo:inline keep-with-next.within-line="always"
       padding-end="0.2em"
       xsl:use-attribute-sets="variablelist.term.properties">
-      <xsl:copy-of select="$title-str"/>
+      <xsl:copy-of select="$titlestr"/>
       <xsl:if test="$last-char != ''
                     and not(contains($runinhead.title.end.punct, $last-char))">
         <xsl:call-template name="gentext">
           <xsl:with-param name="key">runinhead.default.title.end.punct</xsl:with-param>
         </xsl:call-template>
       </xsl:if>
-      <fo:leader leader-pattern="space" leader-length=".3em"/>
+      <!-- <fo:leader leader-pattern="space" leader-length=".3em"/> -->
     </fo:inline>
   </xsl:if>
 </xsl:template>

--- a/suse2022-ns/xhtml/block.xsl
+++ b/suse2022-ns/xhtml/block.xsl
@@ -130,9 +130,10 @@
   <xsl:variable name="titleStr">
       <xsl:apply-templates/>
   </xsl:variable>
+  <xsl:variable name="ns-titleStr" select="normalize-space($titleStr)"/>
   <xsl:variable name="lastChar">
-    <xsl:if test="$titleStr != ''">
-      <xsl:value-of select="substring($titleStr,string-length($titleStr),1)"/>
+    <xsl:if test="normalize-space($ns-titleStr) != ''">
+      <xsl:value-of select="substring($ns-titleStr, string-length($ns-titleStr), 1)"/>
     </xsl:if>
   </xsl:variable>
 
@@ -143,7 +144,7 @@
         <xsl:with-param name="key">runinhead.default.title.end.punct</xsl:with-param>
       </xsl:call-template>
     </xsl:if>
-    <xsl:text>&#160;</xsl:text>
+    <!--<xsl:text>&#160;</xsl:text>-->
   </span>
 </xsl:template>
 


### PR DESCRIPTION
Julia reported, that zh-cn/zh-tw does not need the additional space between the formalpara/title and the next para.

English and other languages, contains now the punctuation and the non-breakable space.