### PR TITLE
Prepare structural tabs support presentation of variablelist

### DIFF
--- a/suse2022-ns/xhtml/lists.xsl
+++ b/suse2022-ns/xhtml/lists.xsl
@@ -18,6 +18,117 @@
     xmlns="http://www.w3.org/1999/xhtml"
     exclude-result-prefixes="exsl d">
 
+  <xsl:template match="d:variablelist">
+    <xsl:variable name="pi-presentation">
+      <xsl:call-template name="pi.dbhtml_list-presentation" />
+    </xsl:variable>
+    <!-- Handle spacing="compact" as multiple class attribute instead
+       of the deprecated HTML compact attribute -->
+
+    <xsl:variable name="presentation">
+      <xsl:choose>
+        <xsl:when test="$pi-presentation != ''">
+          <xsl:value-of select="$pi-presentation" />
+        </xsl:when>
+        <xsl:when test="$variablelist.as.table != 0">
+          <xsl:value-of select="'table'" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="'list'" />
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
+    <xsl:variable name="default.class">
+      <xsl:value-of select="local-name()" />
+      <xsl:if test="@spacing = 'compact'">
+        <xsl:text> compact</xsl:text>
+      </xsl:if>
+      <!-- Added to support tabs -->
+      <xsl:if test="@role = 'tabs' or $presentation = 'tabs'">
+        <xsl:text> tabs</xsl:text>
+      </xsl:if>
+    </xsl:variable>
+
+    <xsl:variable name="list-width">
+      <xsl:call-template name="pi.dbhtml_list-width" />
+    </xsl:variable>
+
+    <xsl:variable name="term-width">
+      <xsl:call-template name="pi.dbhtml_term-width" />
+    </xsl:variable>
+
+    <xsl:variable name="table-summary">
+      <xsl:call-template name="pi.dbhtml_table-summary" />
+    </xsl:variable>
+
+  <div>
+    <xsl:call-template name="common.html.attributes"/>
+    <xsl:call-template name="id.attribute"/>
+    <xsl:call-template name="anchor"/>
+    <xsl:if test="d:title|d:info/d:title">
+      <xsl:call-template name="formal.object.heading"/>
+    </xsl:if>
+
+      <xsl:choose>
+        <xsl:when test="$presentation = 'table'">
+          <!-- Preserve order of PIs and comments -->
+          <xsl:apply-templates
+            select="*[not(self::d:varlistentry or self::d:title or self::d:titleabbrev)]
+                    | comment()[not(preceding-sibling::d:varlistentry)]
+                    | processing-instruction()[not(preceding-sibling::d:varlistentry)]" />
+          <table border="{$table.border.off}">
+            <xsl:call-template name="generate.class.attribute">
+              <xsl:with-param name="class" select="$default.class" />
+            </xsl:call-template>
+            <xsl:if test="$list-width != ''">
+              <xsl:attribute name="width">
+                <xsl:value-of select="$list-width" />
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="$table-summary != ''">
+              <xsl:attribute name="summary">
+                <xsl:value-of select="$table-summary" />
+              </xsl:attribute>
+            </xsl:if>
+            <colgroup>
+              <col align="{$direction.align.start}" valign="top">
+                <xsl:if test="$term-width != ''">
+                  <xsl:attribute name="width">
+                    <xsl:value-of select="$term-width" />
+                  </xsl:attribute>
+                </xsl:if>
+              </col>
+              <col />
+            </colgroup>
+            <tbody>
+              <xsl:apply-templates mode="varlist-table"
+                select="d:varlistentry | comment()[preceding-sibling::d:varlistentry]
+                        | processing-instruction()[preceding-sibling::d:varlistentry]"
+               />
+            </tbody>
+          </table>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- Preserve order of PIs and comments -->
+          <xsl:apply-templates
+            select="*[not(self::d:varlistentry or self::d:title or self::d:titleabbrev)]
+                    | comment()[not(preceding-sibling::d:varlistentry)]
+                    | processing-instruction()[not(preceding-sibling::d:varlistentry)]" />
+          <dl>
+            <xsl:call-template name="generate.class.attribute">
+              <xsl:with-param name="class" select="$default.class" />
+            </xsl:call-template>
+            <xsl:apply-templates
+              select="d:varlistentry | comment()[preceding-sibling::d:varlistentry]
+                      | processing-instruction()[preceding-sibling::d:varlistentry]"
+             />
+          </dl>
+        </xsl:otherwise>
+      </xsl:choose>
+  </div>
+  </xsl:template>
+
 
   <xsl:template match="d:varlistentry">
     <dt>


### PR DESCRIPTION
"Tabs" presentation is rendered "inline" and `<term>`s become tab titles. To enable it, there are two possibilities:

* With role

  ```xml
  <variablelist role="tabs">`
  ```

* With PI
      
  ```xml
  <variablelist>
     <?dbhtml list-presentation="tabs"?>
  ```

# Input

```xml
<variablelist role="tabs">
   <varlistentry>
      <term>Geeko</term>
      <listitem>
         <para>The SUSE mascot</para>
      </listitem>
   </varlistentry>
<variablelist>
```

# Output
The following structure is created:

```html
<div class="variablelist">
  <dl class="variablelist tabs">
     <dt id="..."><span class="term">Geeko</span></dt>
     <dd>
        <p>The SUSE mascot</p>
     </dd>
  </dl>

</div>
```

# TODO

* [ ] CSS
* [ ] JS