### PR TITLE
Fix missing 3 column layout

### DIFF
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -701,10 +701,10 @@
 
 
   <!-- ############################################################## -->
-  <xsl:template match="d:book|d:article|d:set" priority="2" mode="process.root">
+
+  <xsl:template match="/" mode="process.root">
     <xsl:apply-imports/>
-    <xsl:if test="$rootid = @xml:id and $is.chunk = 0">
-      <xsl:choose>
+    <xsl:choose>
         <xsl:when test="$dcfilename != ''">
           <xsl:call-template name="generate-json-ld-external">
             <xsl:with-param name="node" select="." />
@@ -717,19 +717,11 @@
               <xsl:text>JSON-LD</xsl:text>
             </xsl:with-param>
             <xsl:with-param name="message">
-              <xsl:text>The parameter $dcfile is unset. Cannot find the DC file in Docserv config.</xsl:text>
+              <xsl:text>The parameter $dcfilename is unset. Cannot create the external JSON file.</xsl:text>
             </xsl:with-param>
           </xsl:call-template>
         </xsl:otherwise>
       </xsl:choose>
-    </xsl:if>
-  </xsl:template>
-
-  <xsl:template match="/" priority="2" mode="process.root">
-    <xsl:apply-imports/>
-    <xsl:call-template name="generate-json-ld-external">
-      <xsl:with-param name="node" select="/*"/>
-    </xsl:call-template>
   </xsl:template>
 
   <xsl:template match="*" mode="process.root">


### PR DESCRIPTION
* Remove template `d:book|d:article|d:set` in mode="process.root"
* Integrate call of `generate-json-ld-external` into "/" of mode="process.root"