### PR TITLE
Add linebreaks in titlepage for SBPs

### DIFF
--- a/sbp/xhtml/titlepage.templates.xsl
+++ b/sbp/xhtml/titlepage.templates.xsl
@@ -78,6 +78,10 @@
   </xsl:template>
 
 
+  <xsl:template match="d:abstract/d:*" mode="article.titlepage.recto.auto.mode">
+    <xsl:apply-templates select="."/>
+  </xsl:template>
+
   <xsl:template match="d:author[d:personname]|d:editor[d:personname]|d:othercredit[d:personname]"  mode="authorgroup">
     <xsl:param name="withlabel" select="1"/>
 <!--<xsl:message>d:<xsl:value-of select="local-name(.)"/>[d:personname]</xsl:message>  -->


### PR DESCRIPTION
Reported by Meike.

In `abstract/para` there were no `<p>` tags in the output. Which lead to a wall of text without linebreaks.

Solution was to introduce a rule that matches d:abstract/d:para in mode `article.titlepage.recto.auto.mode`.

---

Example of improved output:

![Screenshot_20240220_170805](https://github.com/openSUSE/suse-xsl/assets/1312925/a3e1f517-d264-4fa9-9fb0-767fa4f06b12)
