### PR TITLE
Introduce json-ld-base.dir parameter

### DIFF
--- a/suse2022-ns/xhtml/json-ld.xsl
+++ b/suse2022-ns/xhtml/json-ld.xsl
@@ -238,12 +238,12 @@
         select="$filename"/>" for <xsl:value-of select="local-name($node)"/>
       Found <xsl:value-of select="count($stitchxml)"/> node(s) (=<xsl:value-of select="local-name($stitchxml)"/>).
       <xsl:if test="$dcfilename">Found DC filename "<xsl:value-of select="$dcfilename"/>"</xsl:if>
-      base.dir="<xsl:value-of select="$base.dir"/>"
+      json-ld-base.dir="<xsl:value-of select="$json-ld-base.dir"/>"
       filename="<xsl:value-of select="$filename"/>"
       </xsl:message>
       -->
       <xsl:call-template name="write.chunk">
-        <xsl:with-param name="filename" select="concat($base.dir, $filename)"/>
+        <xsl:with-param name="filename" select="concat($json-ld-base.dir, $filename)"/>
         <xsl:with-param name="quiet" select="0"/>
         <xsl:with-param name="method">text</xsl:with-param>
         <xsl:with-param name="doctype-public"/>

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -467,6 +467,8 @@ task before
   <xsl:param name="generate.json-ld.external" select="0"/>
   <!-- Filename to the single stitch file that Docserv generates on startup -->
   <xsl:param name="stitchfile"/>
+  <!-- The base.dir to store all external JSON files -->
+  <xsl:param name="json-ld-base.dir" select="$base.dir"/>
   <!-- Should the individual authors be used? 0=no, 1=yes  -->
   <xsl:param name="json-ld-use-individual-authors" select="1"/>
   <!-- File extension -->


### PR DESCRIPTION
This PR introduces the parameter `json-ld-base.dir`:

```
json-ld-base.dir: base directory for all external JSON files (default $base.dir)
```

By default, it's defined as "$base.dir". It is used to collect all files under one roof (=directory). If unset, it falls back to `base.dir` and stores the external JSON files at the same location than the HTML files.

This makes the search-and-integrate algorithm in Docserv code easier.