### PR TITLE
Fix handling of external JSON-LD generation

### DIFF
--- a/suse2022-ns/xhtml/chunk.xsl
+++ b/suse2022-ns/xhtml/chunk.xsl
@@ -39,4 +39,26 @@
 
   <xsl:param name="is.chunk" select="1"/>
 
+
+  <xsl:template match="/">
+    <xsl:apply-imports/>
+    <xsl:choose>
+      <xsl:when test="$dcfilename != ''">
+        <xsl:call-template name="generate-json-ld-external">
+          <xsl:with-param name="node" select="*[1]" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="log.message">
+          <xsl:with-param name="level">WARN</xsl:with-param>
+          <xsl:with-param name="context-desc">
+            <xsl:text>JSON-LD</xsl:text>
+          </xsl:with-param>
+          <xsl:with-param name="message">
+            <xsl:text>The parameter $dcfilename is unset. Cannot create the external JSON file.</xsl:text>
+          </xsl:with-param>
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -701,10 +701,11 @@
 
 
   <!-- ############################################################## -->
-
-  <xsl:template match="/" mode="process.root">
+  <!-- This template is called when creating single HTML -->
+  <xsl:template match="/">
     <xsl:apply-imports/>
-    <xsl:choose>
+    <xsl:if test="$is.chunk = 0">
+      <xsl:choose>
         <xsl:when test="$dcfilename != ''">
           <xsl:call-template name="generate-json-ld-external">
             <xsl:with-param name="node" select="." />
@@ -722,6 +723,7 @@
           </xsl:call-template>
         </xsl:otherwise>
       </xsl:choose>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="*" mode="process.root">
@@ -1025,6 +1027,5 @@ if (window.location.protocol.toLowerCase() != 'file:') {
       <xsl:text> </xsl:text>
     </aside>
   </xsl:template>
-
 
 </xsl:stylesheet>

--- a/suse2022-ns/xhtml/json-ld.xsl
+++ b/suse2022-ns/xhtml/json-ld.xsl
@@ -218,7 +218,10 @@
       </xsl:variable>
       <xsl:variable name="file" select="substring-after($dcfile, 'DC-')"/>
       <xsl:choose>
-        <xsl:when test="$base != ''">
+        <xsl:when test="$base != '' and $rootid != ''">
+          <xsl:value-of select="concat($rootid, $json-ld.ext)"/>
+        </xsl:when>
+        <xsl:when test="$base != '' and $rootid = ''">
           <xsl:value-of select="concat($base, $json-ld.ext)"/>
         </xsl:when>
         <xsl:otherwise>
@@ -233,6 +236,9 @@
     </xsl:variable>
 
     <xsl:if test="$generate.json-ld.external != 0">
+      <xsl:variable name="lang">
+        <xsl:call-template name="l10n.language"/>
+      </xsl:variable>
       <!--
         <xsl:message>Going to write external JSON-LD structure to "<xsl:value-of
         select="$filename"/>" for <xsl:value-of select="local-name($node)"/>
@@ -242,8 +248,10 @@
       filename="<xsl:value-of select="$filename"/>"
       </xsl:message>
       -->
+
+      <!-- We take into account the language as well -->
       <xsl:call-template name="write.chunk">
-        <xsl:with-param name="filename" select="concat($json-ld-base.dir, $filename)"/>
+        <xsl:with-param name="filename" select="concat($json-ld-base.dir, $lang, '-', $filename)"/>
         <xsl:with-param name="quiet" select="0"/>
         <xsl:with-param name="method">text</xsl:with-param>
         <xsl:with-param name="doctype-public"/>

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -460,7 +460,7 @@ task before
   <xsl:param name="include.ssi.footer">/docserv/fragments/suseparts/footer_{{#language#}}.html</xsl:param>
 
   <!-- Should we generate a JSON-LD structure? 0=no, 1=yes -->
-  <xsl:param name="generate.json-ld" select="0"/>
+  <xsl:param name="generate.json-ld" select="1"/>
   <!-- Should we generate an external JSON-LD structure 0=no, 1=yes
        Only works when $generate.json-ld=1 was set
   -->


### PR DESCRIPTION
Some DC files didn't create the JSON-LD structure. This fix should get around it.

This PR contains:

* Fix for creating the external JSON-LD file
* Add language part into external JSON-LD filename to distinguish the same filename (basic structure is `concat($json-ld-base.dir, $lang, '-', $filename)`
* Fix a problem on doc-sle; taking into account $rootid parameter when set to avoid overwriting JSON file.
* Enable JSON-LD structure for HTML by default


