### PR TITLE
Corrected handling of dateModified & datePublished

### DIFF
--- a/suse2022-ns/common/utility.xsl
+++ b/suse2022-ns/common/utility.xsl
@@ -211,4 +211,5 @@
 
     <xsl:value-of select="$lang-attr"/>
   </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
Fix DOCTEAM#1367

This PR contains the following changes:

* Combine separate `json-ld-dateModified` and `json-ld-datePublished` into `json-ld-dateModified-and-Published`.
  Produce only an entry, if dates are valid and if `datePublished < dateModified`
  Use first `revhistory/revision/date` for `dateModified` and last `revhistory/revision/date` for `datePublished`.
* Revamp `santize-date(date)` template date can be any date in the format `YYYY-M`, `YYYY-MM`, `YYYY-M-D`, `YYYY-MM-D`, `YYYY-M-DD`, or `YYYY-MM-DD`. If the date doesn't conform to any of these formats, an empty string is returned.
* Add new `validate-date(date)` template $date should be in the format of `YYYY-MM-DDTHH:MMZ`, but only the `YYYY-MM-DD` is checked. If the date is valid, true() is return, otherwise false()
* Add `compare-dates(date1, date2)`
  Compare two dates lexicographically. Return -1 if `date1 < date2`; 0 if `date1 == date2`; 1 if `date1 > date2`.

---

In simple words, the stylesheet follows this approach:

1. Retrieve the possible date elements from `<revhistory>`.
2. Sanitize different formats into the consistent ISO format YYYY-MM-DDTHH:MMZ
3. Validate the dates
4. Compare the dates so it follows `datePublished < dateModified`
5. If this is all correct, create the respective JSON-LD structure. If there are invalid dates, skip it.