### PR TITLE
Fix #649: Provide unique alt attribute for <img>

### DIFF
--- a/suse2022-ns/xhtml/graphics.xsl
+++ b/suse2022-ns/xhtml/graphics.xsl
@@ -534,7 +534,7 @@
                 <xsl:when test="$alt != ''">
                   <xsl:copy-of select="$alt" />
                 </xsl:when>
-                <xsl:when test="ancestor::figure">
+                <xsl:when test="ancestor::d:figure">
                   <xsl:variable name="fig.title">
                     <xsl:apply-templates select="ancestor::figure/title/node()"
                      />
@@ -931,16 +931,27 @@
       <xsl:when test="../../d:textobject/d:phrase">
           <xsl:apply-templates select="../../d:textobject/d:phrase/node()"/>
       </xsl:when>
-      <xsl:when test="../../../d:caption">
-        <xsl:apply-templates select="../../../d:caption/node()"/>
+      <xsl:when test="../../../d:caption[d:para]">
+        <xsl:apply-templates select="../../../d:caption/d:para[1]"/>
       </xsl:when>
-      <xsl:when test="../../../d:title">
-        <xsl:apply-templates select="../../../d:title/node()"/>
+      <xsl:when test="ancestor::d:figure/d:title">
+        <xsl:value-of select="ancestor::d:figure/d:title"/>
       </xsl:when>
       <xsl:when test="$alt != ''">
         <xsl:value-of select="$alt"/>
       </xsl:when>
-      <xsl:otherwise>Image</xsl:otherwise>
+      <xsl:when test="ancestor::d:informalfigure">
+        <xsl:variable name="candidate-title"
+          select="(ancestor::*[d:title][1]/d:title | ancestor::*[d:info/d:title][1]/d:info/d:title)[last()]"/>
+        <xsl:variable name="image-number"
+          select="count(ancestor::d:informalfigure/preceding-sibling::d:informalfigure) + 1"/>
+        <xsl:value-of select="concat('#',  $image-number, ': ', $candidate-title)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:variable name="candidate-title"
+          select="(ancestor::*[d:title][1]/d:title | ancestor::*[d:info/d:title][1]/d:info/d:title)[last()]"/>
+        <xsl:value-of select="$candidate-title"/>
+      </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
 


### PR DESCRIPTION
Siteimprove reports that the alt attribute in `<img alt="Image" .../>` is not unique. It expects an unique text.

This implementation tries to make the alt text unique and uses this algorithm:

1. Look for a `<textobject>` in `informalfigure`:
   a. If found, use it and stop processing.
   b. If it doesn't exist, continue.
3. Search for a `caption/para[1]`, a `title`, or a `info/title` in this order. If found, use it and stop processing. If not, continue.
4. If neither of this strategy works, extract the title from the hierarchy element (section, chapter, ...).
3. If we have more than one `<informalfigure>` in the same hierarchy, number it.
6. Combine the number from the previous step and the title from step 2 and use it as alt text.
7. Done.