### PR TITLE
DOCTEAM#1664: Fix aria-label for revhistory link

### DIFF
--- a/suse2022-ns/xhtml/titlepage.xsl
+++ b/suse2022-ns/xhtml/titlepage.xsl
@@ -154,11 +154,12 @@
             </xsl:otherwise>
           </xsl:choose>
         </xsl:variable>
+        <xsl:variable name="str.title" select="string($title)"/>
 
         <!-- Create the link to the revhistory page -->
         <div class="titlepage-revhistory">
-          <a aria-label="{$revhistory.text}" hreflang="{$candidate.lang}"
-             href="{$file}" target="_blank"><xsl:copy-of select="string($title)" /></a>
+          <a aria-label="{$str.title}" hreflang="{$candidate.lang}"
+             href="{$file}" target="_blank"><xsl:copy-of select="$str.title" /></a>
         </div>
 
         <xsl:call-template name="write.chunk">


### PR DESCRIPTION
This fixes the `aria-label` in this HTML snippet:

```html
<a aria-label="Revision History" hreflang="en" target="_blank" href="...">
Revision History: The Title
</a>
```

With this fix, the `aria-label` is the same as the `<a>` content