### PR TITLE
Empty HTML `<meta name="description">`

### DIFF
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -372,13 +372,15 @@
   <xsl:template name="ellipsize.text">
     <xsl:param name="input" select="''"/>
     <xsl:param name="ellipsize.after" select="150"/>
+    <xsl:variable name="input-ns" select="normalize-space($input)"/>
+
     <xsl:choose>
-      <xsl:when test="string-length(normalize-space($input)) &gt; $ellipsize.after">
-        <xsl:value-of select="substring(normalize-space($input),1,$ellipsize.after - 1)"/>
+      <xsl:when test="string-length($input-ns) &gt; $ellipsize.after">
+        <xsl:value-of select="substring($input-ns, 1, $ellipsize.after - 1)"/>
         <xsl:text>…</xsl:text>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="normalize-space($input)"/>
+        <xsl:value-of select="$input-ns"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -197,13 +197,23 @@
           <!-- For single-html books/articles, it is important that we skip
           the legalnotice. "© SUSE 20XX" is not a good page description
           usually. -->
-          <xsl:when test="self::d:book">
-            <xsl:apply-templates select="(*[self::d:preface or self::d:chapter or self::d:sect1 or self::d:section]/d:para |
-                                          *[self::d:preface or self::d:chapter or self::d:sect1 or self::d:section]/d:simpara)[1]"/>
+          <xsl:when test="self::d:book[(self::d:preface | self::d:chapter | self::d:topic)/d:para]">
+            <xsl:apply-templates select="(*[self::d:preface or self::d:chapter or self::d:topic]/d:para |
+                                          *[self::d:preface or self::d:chapter or self::d:topic]/d:simpara)[1]"/>
+          </xsl:when>
+          <xsl:when test="self::d:book | self::d:appendix | self::d:chapter | self::d:part | self::d:glossary | self::d:preface">
+            <xsl:value-of select="normalize-space(string((d:title|d:info/d:title)[last()]))"/>
           </xsl:when>
           <xsl:when test="self::d:article">
             <xsl:apply-templates select="(*[self::d:sect1 or self::d:section]/d:para |
                                           *[self::d:sect1 or self::d:section]/d:simpara)[1]"/>
+          </xsl:when>
+          <xsl:when test="self::d:revhistory">
+            <xsl:call-template name="gentext">
+              <xsl:with-param name="key" select="'RevHistory'" />
+            </xsl:call-template>
+            <xsl:text>: </xsl:text>
+            <xsl:value-of select="(d:title[normalize-space(.) != ''] | d:revision[1]/d:revdescription/d:para[1])[last()]"/>
           </xsl:when>
           <xsl:otherwise>
             <xsl:apply-templates select="(descendant::d:para | descendant::d:simpara)[1]"/>
@@ -315,6 +325,7 @@
 
   <meta name="title" content="{$search.title}"/>
   <xsl:text>&#10;</xsl:text>
+
   <meta name="description" content="{$search.description}"/>
   <xsl:text>&#10;</xsl:text>
 


### PR DESCRIPTION
Siteimprove reported an empty `<meta name="description">` element (happened on SLE12 SP6). As the old docs don't have a DocBook 5 `<meta>` tag, it needs to be a bit more clever and tries the following elements in this order:

1. Try to find a DocBook 5 `d:meta[@name="description"]`.
2. Try to find `d:info/d:abstract` or `d:info/d:highlights`.
3. Try to find a `d:book` element which contains an  `preface`, `chapter`, or `topic` element which has a `para` or `simpara` element.
4. Try to find a `d:book`, `d:appendix`, `d:chapter`, `d:part`, `d:glossary`, or `d:preface`.
5. Try to find a `d:article`.
6. Try to find a `d:revhistory`.
7. If anything fails, create a set of descendant `d:para` or `d:simpara` elements and use only the first element of that set.