### PR TITLE
DOCTEAM-1663: element is not keyboard accessible

### DIFF
--- a/suse2022-ns/xhtml/chunk-common.xsl
+++ b/suse2022-ns/xhtml/chunk-common.xsl
@@ -328,7 +328,7 @@
                       //*[@xml:id = $rootid][self::d:set or self::d:book[d:article]]">1</xsl:if>
       </xsl:variable>
 
-      <nav id="_side-toc-overall">
+      <nav id="_side-toc-overall" tabindex="0">
         <xsl:attribute name="class">
           <xsl:text>side-toc</xsl:text>
           <xsl:if test="self::d:set">


### PR DESCRIPTION
A scrollable element (`<nav  class="side-toc" id="_side-toc-overall">`) is not keyboard accessible.

Siteimprove recommends to use `tabindex="0"` on the `<nav>` element.