### PR TITLE
Fix DOCTEAM-1663: Container element is empty

### DIFF
--- a/suse2022-ns/xhtml/sidetoc.xsl
+++ b/suse2022-ns/xhtml/sidetoc.xsl
@@ -192,7 +192,7 @@
           </a>
 
           <xsl:if test="$needs.subtoc = 1">
-            <ol>
+            <ol role="list">
               <xsl:apply-templates mode="bubble-toc" select="$nodes">
                 <xsl:with-param name="toc-context" select="$toc-context"/>
                 <xsl:with-param name="page-context-id" select="$page-context-id"/>


### PR DESCRIPTION
Part 2, missing an empty `<ol>` which should `<ol role="list">`