### PR TITLE
Fix #639: Disable hyphenation in article/book titles

### DIFF
--- a/suse2022-ns/fo/article.titlepage.templates.xsl
+++ b/suse2022-ns/fo/article.titlepage.templates.xsl
@@ -56,7 +56,8 @@
       </fo:instream-foreign-object>
     </fo:block>
 
-    <fo:block start-indent="{&columnfragment; + &gutter;}mm" text-align="start"
+    <fo:block start-indent="{&columnfragment; + &gutter;}mm"
+      hyphenate="false" text-align="start"
       role="article.titlepage.recto">
       <fo:block space-after="{&gutterfragment;}mm">
         <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
@@ -84,9 +85,8 @@
         </xsl:choose>
       </fo:block>
 
-    <fo:block padding-before="{2 * &gutterfragment;}mm"
+    <fo:block padding-before="{2 * &gutterfragment;}mm" hyphenate="false"
       padding-start="{&column; + &columnfragment; + &gutter;}mm">
-
       <xsl:choose>
         <xsl:when test="d:articleinfo/d:subtitle">
           <xsl:apply-templates

--- a/suse2022-ns/fo/book.titlepage.templates.xsl
+++ b/suse2022-ns/fo/book.titlepage.templates.xsl
@@ -113,7 +113,7 @@
                     <fo:block> </fo:block>
                   </fo:table-cell>
                   <fo:table-cell>
-                    <fo:block padding-after="&gutterfragment;mm">
+                    <fo:block padding-after="&gutterfragment;mm" hyphenate="false">
                       <xsl:choose>
                         <xsl:when test="d:bookinfo/d:title">
                           <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
@@ -156,7 +156,7 @@
 <xsl:template match="d:subtitle" mode="book.titlepage.recto.auto.mode">
   <fo:block
     xsl:use-attribute-sets="title.font" font-size="{&super-large; * $sans-fontsize-adjust}pt"
-    space-before="&gutterfragment;mm">
+    space-before="&gutterfragment;mm"  hyphenate="false">
     <xsl:apply-templates select="." mode="book.titlepage.recto.mode"/>
   </fo:block>
 </xsl:template>


### PR DESCRIPTION
Tested with several languages, this is `DC-SLES-installation` fr:

![Screenshot_20250212_145151](https://github.com/user-attachments/assets/b3d740f8-8e47-4084-8680-669a11bab827)
