### PR TITLE
Fix #645: Remove whitespace in title

### DIFF
--- a/suse2022-ns/fo/xref.xsl
+++ b/suse2022-ns/fo/xref.xsl
@@ -26,6 +26,7 @@
   xmlns:exsl="http://exslt.org/common"
   exclude-result-prefixes="xlink exsl d">
 
+  <xsl:strip-space elements="d:title"/>
 
 <xsl:template match="d:ulink|d:link" name="ulink">
   <xsl:param name="url" select="(@url|@xlink:href)[last()]"/>


### PR DESCRIPTION
It looks easy, but it can quickly become quite complicated. This fix is a small attempt and it seems it works in this cases:

```xml
<title>
   <phrase>Welcome to &productname;</phrase>
</title>
```

Having an `<xref/>` to this title produces this:

![Screenshot_20250212_130639](https://github.com/user-attachments/assets/695ced2e-adc1-436e-a806-faadfd7335be)

However, due to the flexibility of the title model, it can contain quite a complex structure which may not work in all cases.

For the time being, this is the best approach. If this isn't enough, it is quite difficult to fix.