### PR TITLE
Fix #646: Remove space in compound terms

### DIFF
--- a/suse2022-ns/fo/inline.xsl
+++ b/suse2022-ns/fo/inline.xsl
@@ -88,9 +88,6 @@
     </xsl:otherwise>
    </xsl:choose>
 
-   <xsl:if test="$lighter-formatting != 1">
-    <fo:leader leader-pattern="space" leader-length="0.2em"/>
-   </xsl:if>
    <xsl:call-template name="anchor"/>
    <xsl:if test="@dir">
     <xsl:attribute name="direction">
@@ -106,9 +103,6 @@
    <xsl:copy-of select="$content"/>
    <xsl:if test="$after != ''">
     <xsl:value-of select="$after"/>
-   </xsl:if>
-   <xsl:if test="$lighter-formatting != 1">
-    <fo:leader leader-pattern="space" leader-length="0.2em"/>
    </xsl:if>
   </fo:inline>
 </xsl:template>


### PR DESCRIPTION
For example, this happens in this structure:

```xml
<command>sudo</command-Konfigurationsdateien
```

Between "sudo" and the "-" there is an `<fo:leader/>`. This fix removes this invisible space. This is the result:


![Screenshot_20250212_152414](https://github.com/user-attachments/assets/01f4ad80-b590-4de2-9c98-b5f5023d4254)

