### PR TITLE
Fix #637: Footer runs into the second line

### DIFF
--- a/suse2022-ns/fo/pagesetup.xsl
+++ b/suse2022-ns/fo/pagesetup.xsl
@@ -208,8 +208,8 @@
                    Arabic, so xsl:if this out for the moment. -->
               <xsl:if test="$writing.mode = 'lr'">
                 <fo:inline>
-                  <fo:leader leader-length="&columnfragment;mm"
-                    leader-pattern="space"/>
+                  <xsl:text> | </xsl:text>
+                  <!--<fo:leader leader-length="1em" leader-pattern="space"/>-->
                   <xsl:call-template name="product"/>
                 </fo:inline>
               </xsl:if>
@@ -402,10 +402,10 @@
     block-progression-dimension="auto">
     <!-- Page number -->
     <fo:table-column column-number="1"
-        column-width="{&column; + &gutter;}mm"/>
+        column-width="5%"/>
     <!-- Some titles -->
     <fo:table-column column-number="2"
-        column-width="{(&column; * 5) + (&gutter; *4)}mm"/>
+        column-width="95%"/>
 
       <fo:table-body>
         <fo:table-row>


### PR DESCRIPTION
When the title exceeds a certain limit, the footer breaks into two lines which looks quite ugly.

This fix has the following properties:

* Can handle titles with less than 90 characters. Any title which contains more characters have the same issue.
* Appends the release after `" | "`.
* Stretches the space for title, reduces the space for page numbers.