### PR TITLE
Fix #641: Change emphasis for Asian languages

### DIFF
--- a/suse2022-ns/common/l10n/ar.xml
+++ b/suse2022-ns/common/l10n/ar.xml
@@ -118,6 +118,9 @@ translators apparently want those. - sknorr, 2016-09-30 -->
    </l:context>
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text="" />
 
       <l:template name="example-label" text="المثال&#160;%n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/cs.xml
+++ b/suse2022-ns/common/l10n/cs.xml
@@ -102,6 +102,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text="" />
 
       <l:template name="example-label" text="P&#345;&#237;klad&#160;%n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/da.xml
+++ b/suse2022-ns/common/l10n/da.xml
@@ -75,6 +75,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Eksempel&#160;%n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/de.xml
+++ b/suse2022-ns/common/l10n/de.xml
@@ -76,6 +76,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Beispiel %n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/en.xml
+++ b/suse2022-ns/common/l10n/en.xml
@@ -75,6 +75,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text="" />
 
       <l:template name="example-label" text="Example&#160;%n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/es.xml
+++ b/suse2022-ns/common/l10n/es.xml
@@ -78,6 +78,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Ejemplo %n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/fi.xml
+++ b/suse2022-ns/common/l10n/fi.xml
@@ -59,6 +59,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Esimerkki&#160;%n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/fr.xml
+++ b/suse2022-ns/common/l10n/fr.xml
@@ -78,6 +78,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Exemple %n&#160;:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/hu.xml
+++ b/suse2022-ns/common/l10n/hu.xml
@@ -80,6 +80,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="%n.&#160;p&#233;lda:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/it.xml
+++ b/suse2022-ns/common/l10n/it.xml
@@ -76,6 +76,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Esempio %n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/ja.xml
+++ b/suse2022-ns/common/l10n/ja.xml
@@ -75,6 +75,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text="「"/>
+      <l:template name="emphasis-close" text="」"/>
+      <l:template name="emphasis-style" text="" />
 
       <l:template name="example-label" text="&#20363; %n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/ko.xml
+++ b/suse2022-ns/common/l10n/ko.xml
@@ -78,6 +78,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text="bold" />
 
       <l:template name="example-label" text="&#50696;&#51228; %n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/lt_lt.xml
+++ b/suse2022-ns/common/l10n/lt_lt.xml
@@ -66,6 +66,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="%n&#160;pavyzdys:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/nl.xml
+++ b/suse2022-ns/common/l10n/nl.xml
@@ -74,6 +74,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Voorbeeld&#160;%n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/no.xml
+++ b/suse2022-ns/common/l10n/no.xml
@@ -68,6 +68,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Eksempel&#160;%n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/pl.xml
+++ b/suse2022-ns/common/l10n/pl.xml
@@ -74,6 +74,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Przykład&#160;%n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/pt_br.xml
+++ b/suse2022-ns/common/l10n/pt_br.xml
@@ -75,6 +75,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Exemplo&#160;%n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/ru.xml
+++ b/suse2022-ns/common/l10n/ru.xml
@@ -74,6 +74,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Пример %n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/sv.xml
+++ b/suse2022-ns/common/l10n/sv.xml
@@ -56,6 +56,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text=""/>
 
       <l:template name="example-label" text="Exempel&#160;%n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/zh_cn.xml
+++ b/suse2022-ns/common/l10n/zh_cn.xml
@@ -110,6 +110,9 @@
 
   <l:context name="styles">
     <l:template name="person-name" text="first-last"/>
+    <l:template name="emphasis-open" text=""/>
+    <l:template name="emphasis-close" text=""/>
+    <l:template name="emphasis-style" text="bold"/>
 
     <l:template name="example-label" text="&#20363; %n︰"/>
     <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/common/l10n/zh_tw.xml
+++ b/suse2022-ns/common/l10n/zh_tw.xml
@@ -97,6 +97,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text="bold"/>
 
       <l:template name="example-label" text="&#31684;&#20363; %n︰"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/fo/inline.xsl
+++ b/suse2022-ns/fo/inline.xsl
@@ -353,6 +353,63 @@
 </xsl:template>
 
 
+<xsl:template match="d:emphasis">
+  <xsl:variable name="open">
+    <xsl:call-template name="gentext.template">
+      <xsl:with-param name="context" select="'styles'"/>
+      <xsl:with-param name="name" select="concat( local-name(),'-open')"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="close">
+    <xsl:call-template name="gentext.template">
+      <xsl:with-param name="context" select="'styles'"/>
+      <xsl:with-param name="name" select="concat( local-name(),'-close')"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="style">
+    <xsl:call-template name="gentext.template">
+      <xsl:with-param name="context" select="'styles'"/>
+      <xsl:with-param name="name" select="concat( local-name(),'-style')"/>
+    </xsl:call-template>
+  </xsl:variable>
+
+  <xsl:copy-of select="$open"/>
+  <xsl:choose>
+    <xsl:when test="$style='bold' or @role='bold' or @role='strong'">
+      <xsl:call-template name="inline.boldseq"/>
+    </xsl:when>
+    <xsl:when test="@role='underline'">
+      <fo:inline text-decoration="underline">
+        <xsl:call-template name="inline.charseq"/>
+      </fo:inline>
+    </xsl:when>
+    <xsl:when test="@role='strikethrough'">
+      <fo:inline text-decoration="line-through">
+        <xsl:call-template name="inline.charseq"/>
+      </fo:inline>
+    </xsl:when>
+    <xsl:otherwise>
+      <!-- How many regular emphasis ancestors does this element have -->
+      <xsl:variable name="depth" select="count(ancestor::d:emphasis
+        [not(contains(' bold strong underline strikethrough ', concat(' ', @role, ' ')))]
+        )"/>
+
+      <xsl:choose>
+        <xsl:when test="$depth mod 2 = 1">
+          <fo:inline font-style="normal">
+            <xsl:apply-templates/>
+          </fo:inline>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:call-template name="inline.italicseq"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:otherwise>
+  </xsl:choose>
+  <xsl:copy-of select="$close"/>
+</xsl:template>
+
+
 <!-- Mode: mono-ancestor -->
 <xsl:template match="d:command|d:userinput" mode="mono-ancestor">
  <xsl:param name="purpose" select="'none'"/>
@@ -404,6 +461,20 @@
 </xsl:template>
 
 <xsl:template match="d:emphasis" mode="mono-ancestor">
+  <xsl:variable name="open">
+    <xsl:call-template name="gentext.template">
+      <xsl:with-param name="context" select="'styles'"/>
+      <xsl:with-param name="name" select="concat( local-name(),'-open')"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="close">
+    <xsl:call-template name="gentext.template">
+      <xsl:with-param name="context" select="'styles'"/>
+      <xsl:with-param name="name" select="concat( local-name(),'-close')"/>
+    </xsl:call-template>
+  </xsl:variable>
+
+ <xsl:copy-of select="$open"/>
  <xsl:choose>
   <xsl:when test="@role='bold' or @role='strong'">
    <xsl:call-template name="inline.boldmonoseq">
@@ -416,6 +487,7 @@
   </xsl:call-template>
   </xsl:otherwise>
  </xsl:choose>
+ <xsl:copy-of select="$close"/>
 </xsl:template>
 
 <xsl:template match="d:keycap">


### PR DESCRIPTION
Add an open and close glyph at the start and end of the emphasis output.

----

This is the test paragraph:

```xml
<para>
   Test: <emphasis>サポート</emphasis>
</para>
<para xml:lang="ko-kr">
   Test ko-kr: 지원되지 <emphasis>않습니다</emphasis>
</para>
<para xml:lang="zh-cn">
  Test zh-cn: 最可靠的方式是<emphasis>修补</emphasis>
</para>
```

The result is for Japanese:

![Screenshot_20250224_160845](https://github.com/user-attachments/assets/6b404779-c583-453a-86f9-e309d91b6dcf)

