### PR TITLE
Add rel="preload" for `xhtml/docbook.xsl`

### DIFF
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -853,7 +853,7 @@
 
     <xsl:if test="$build.for.web = 1">
       <!-- https://www.suse.com/assets/css/google-fonts-suse.css?avs=1733925891" -->
-      <link rel="stylesheet" type="text/css"
+      <link rel="stylesheet" type="text/css" rel="preload"
         href="https://documentation.suse.com/docserv/res/fonts/suse/suse.css" />
     </xsl:if>
 <!--     <xsl:if test="$daps.header.js.library != ''">


### PR DESCRIPTION
Enable us to test the SUSE font on docserv.