### PR TITLE
Fix #680: double rel, use rel="preload"

### DIFF
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -852,8 +852,8 @@
     <xsl:param name="node" select="."/>
 
     <xsl:if test="$build.for.web = 1">
-      <!-- https://www.suse.com/assets/css/google-fonts-suse.css?avs=1733925891" -->
-      <link rel="stylesheet" type="text/css" rel="preload"
+      <!-- CORS issue: "https://www.suse.com/assets/css/google-fonts-suse.css?avs=1733925891" -->
+      <link type="text/css" rel="preload" as="style"
         href="https://documentation.suse.com/docserv/res/fonts/suse/suse.css" />
     </xsl:if>
 <!--     <xsl:if test="$daps.header.js.library != ''">


### PR DESCRIPTION
# Situation

The validation in the GitHub Action fails because of the attribute `rel` which is used twice. This PR fixes this:

```diff
diff --git a/suse2022-ns/xhtml/docbook.xsl b/suse2022-ns/xhtml/docbook.xsl
index 254e8c3..6700534 100644
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -853,7 +853,7 @@
 
     <xsl:if test="$build.for.web = 1">
       <!-- https://www.suse.com/assets/css/google-fonts-suse.css?avs=1733925891" -->
-      <link rel="stylesheet" type="text/css" rel="preload"
+      <link type="text/css" rel="preload" as="style"
```

# Source
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload
