### PR TITLE
Add missing intra-appendix translations

### DIFF
--- a/suse2022-ns/common/l10n/ar.xml
+++ b/suse2022-ns/common/l10n/ar.xml
@@ -154,6 +154,7 @@ translators apparently want those. - sknorr, 2016-09-30 -->
            stylesheets. Expect issues to crop up. -->
       <l:template name="intra-separator" text="، "/>
       <l:template name="intra-article" text='مقال "%t"'/>
+      <l:template name="intra-appendix" text='"%t" ﻢﻠﺤﻗ'/>
       <l:template name="intra-book" text='كتاب "%t"'/>
       <l:template name="intra-chapter" text='فصل&#160;%n "%t"'/>
       <l:template name="intra-sect1" text='القسم&#160;%n "%t"'/>

--- a/suse2022-ns/common/l10n/cs.xml
+++ b/suse2022-ns/common/l10n/cs.xml
@@ -134,6 +134,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Článek „%t”"/>
+      <l:template name="intra-appendix" text="Příloha „%t”"/>
       <l:template name="intra-book" text="Kniha „%t”"/>
       <l:template name="intra-chapter" text="Kapitola&#160;%n „%t”"/>
       <l:template name="intra-sect1" text="Oddíl&#160;%n „%t”"/>

--- a/suse2022-ns/common/l10n/da.xml
+++ b/suse2022-ns/common/l10n/da.xml
@@ -107,6 +107,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikel “%t” "/>
+      <l:template name="intra-appendix" text="Appendiks “%t” "/>
       <l:template name="intra-book" text="Bog “%t” "/>
       <l:template name="intra-chapter" text="Kapitel&#160;%n “%t”"/>
       <l:template name="intra-sect1" text="Afsnit&#160;%n “%t”"/>

--- a/suse2022-ns/common/l10n/de.xml
+++ b/suse2022-ns/common/l10n/de.xml
@@ -103,6 +103,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikel „%t“"/>
+      <l:template name="intra-appendix" text="Anhang „%t“"/>
       <l:template name="intra-book" text="Buch „%t“"/>
       <l:template name="intra-chapter" text="Kapitel %n „%t“"/>
       <!--<l:template name="intra-part" text="%n „%t”"/>-->

--- a/suse2022-ns/common/l10n/en.xml
+++ b/suse2022-ns/common/l10n/en.xml
@@ -106,6 +106,7 @@
       <l:template name="page.citation" text=" (page&#160;%p)"/>
 
       <l:template name="intra-separator" text=", "/>
+      <l:template name="intra-appendix" text="Appendix “%t”"/>
       <l:template name="intra-article" text="Article “%t”"/>
       <l:template name="intra-book" text="Book “%t”"/>
       <l:template name="intra-chapter" text="Chapter&#160;%n “%t”"/>

--- a/suse2022-ns/common/l10n/es.xml
+++ b/suse2022-ns/common/l10n/es.xml
@@ -125,6 +125,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artículo “%t”"/>
+      <l:template name="intra-appendix" text="Apéndice “%t”"/>
       <l:template name="intra-book" text="Libro “%t”"/>
       <l:template name="intra-chapter" text="Capítulo&#160;%n “%t”"/>
       <l:template name="intra-sect1" text="Sección&#160;%n “%t”"/>

--- a/suse2022-ns/common/l10n/fi.xml
+++ b/suse2022-ns/common/l10n/fi.xml
@@ -91,6 +91,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikkeli ”%t”"/>
+      <l:template name="intra-appendix" text="Liite ”%t”"/>
       <l:template name="intra-book" text="Kirja ”%t”"/>
       <l:template name="intra-chapter" text="Luku&#160;%n ”%t”"/>
       <l:template name="intra-sect1" text="Osa&#160;%n ”%t”"/>

--- a/suse2022-ns/common/l10n/fr.xml
+++ b/suse2022-ns/common/l10n/fr.xml
@@ -105,6 +105,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Article «&#160;%t&#160;»"/>
+      <l:template name="intra-appendix" text="Annexe «&#160;%t&#160;»"/>
       <l:template name="intra-book" text="Manuel «&#160;%t&#160;»"/>
       <l:template name="intra-chapter" text="Chapitre %n «&#160;%t&#160;»"/>
       <l:template name="intra-sect1" text="Section&#160;%n «&#160;%t&#160;»"/>

--- a/suse2022-ns/common/l10n/hu.xml
+++ b/suse2022-ns/common/l10n/hu.xml
@@ -117,6 +117,8 @@
       <l:template name="intra-separator" text=", "/>
       <!--<l:template name="intra-book" text="könyv „%t”"/>-->
       <l:template name="intra-book" text="„%t”"/>
+      <l:template name="intra-article" text="Cikk „%t”"/>
+      <l:template name="intra-appendix" text="Függelék „%t”"/>
       <l:template name="intra-chapter" text="%n.&#160;fejezet (%t)"/>
       <l:template name="intra-sect1" text="%n.&#160;szakasz (%t)"/>
       <l:template name="intra-sect2" text="%n.&#160;szakasz (%t)"/>

--- a/suse2022-ns/common/l10n/it.xml
+++ b/suse2022-ns/common/l10n/it.xml
@@ -115,6 +115,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Articolo «%t»"/>
+      <l:template name="intra-appendix" text="Appendice «%t»"/>
       <l:template name="intra-book" text="Libro «%t»"/>
       <l:template name="intra-chapter" text="Capitolo %n «%t»"/>
       <l:template name="intra-sect1" text="Sezione&#160;%n «%t»"/>

--- a/suse2022-ns/common/l10n/ja.xml
+++ b/suse2022-ns/common/l10n/ja.xml
@@ -102,6 +102,7 @@
 
     <l:template name="intra-separator" text="、"/>
     <l:template name="intra-article" text="項目 「%t」"/>
+    <l:template name="intra-appendix" text="付録 「%t」"/>
     <l:template name="intra-book"    text="『%t』"/>
     <l:template name="intra-chapter" text="第%n章「%t」"/>
     <l:template name="intra-sect1"   text="%n項「%t」"/>

--- a/suse2022-ns/common/l10n/ko.xml
+++ b/suse2022-ns/common/l10n/ko.xml
@@ -105,6 +105,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="문서 “%t”"/>
+      <l:template name="intra-appendix" text="부록 “%t”"/>
       <l:template name="intra-book" text="책 “%t”"/>
       <l:template name="intra-chapter" text="%n장 “%t”"/>
       <l:template name="intra-sect1" text="%n절 “%t”"/>

--- a/suse2022-ns/common/l10n/lt_lt.xml
+++ b/suse2022-ns/common/l10n/lt_lt.xml
@@ -98,6 +98,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Straipsnis „%t“"/>
+      <l:template name="intra-appendix" text="Priedas „%t“"/>
       <l:template name="intra-book" text="Knyga „%t“"/>
       <l:template name="intra-chapter" text="Skyrius&#160;%n „%t“"/>
       <l:template name="intra-sect1" text="Skyrius&#160;%n „%t“"/>

--- a/suse2022-ns/common/l10n/nl.xml
+++ b/suse2022-ns/common/l10n/nl.xml
@@ -106,6 +106,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikel “%t”"/>
+      <l:template name="intra-appendix" text="Bijlage “%t”"/>
       <l:template name="intra-book" text="Boek “%t” "/>
       <l:template name="intra-chapter" text="Hoofdstuk&#160;%n “%t”"/>
       <l:template name="intra-sect1" text="Paragraaf&#160;%n “%t”"/>

--- a/suse2022-ns/common/l10n/no.xml
+++ b/suse2022-ns/common/l10n/no.xml
@@ -100,6 +100,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikkel «%t»"/>
+      <l:template name="intra-appendix" text="Svar «%t»"/>
       <l:template name="intra-book" text="Bok «%t» "/>
       <l:template name="intra-chapter" text="Kapittel&#160;%n «%t»"/>
       <l:template name="intra-sect1" text="Section&#160;%n «%t»"/>

--- a/suse2022-ns/common/l10n/pl.xml
+++ b/suse2022-ns/common/l10n/pl.xml
@@ -106,6 +106,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artykuł „%t”"/>
+      <l:template name="intra-appendix" text="Dodatek „%t”"/>
       <l:template name="intra-book" text="Książka „%t”"/>
       <l:template name="intra-chapter" text="Rozdział %n „%t”"/>
       <l:template name="intra-sect1" text="Sekcja&#160;%n „%t”"/>

--- a/suse2022-ns/common/l10n/pt_br.xml
+++ b/suse2022-ns/common/l10n/pt_br.xml
@@ -102,6 +102,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artigo “%t”"/>
+      <l:template name="intra-appendix" text="Apêndice “%t”"/>
       <l:template name="intra-book" text="Livro “%t”"/>
       <l:template name="intra-chapter" text="Capítulo %n “%t”"/>
       <l:template name="intra-sect1" text="Seção %n “%t”"/>

--- a/suse2022-ns/common/l10n/ru.xml
+++ b/suse2022-ns/common/l10n/ru.xml
@@ -101,6 +101,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Статья «%t»"/>
+      <l:template name="intra-appendix" text="Приложение «%t»"/>
       <l:template name="intra-book" text="Книга «%t»"/>
       <l:template name="intra-chapter" text="Глава %n «%t»"/>
       <l:template name="intra-sect1" text="Раздел&#160;%n «%t»"/>

--- a/suse2022-ns/common/l10n/sv.xml
+++ b/suse2022-ns/common/l10n/sv.xml
@@ -88,6 +88,7 @@
 
       <l:template name="intra-separator" text=", "/>
       <l:template name="intra-article" text="Artikel ”%t”"/>
+      <l:template name="intra-appendix" text="Appendix ”%t”"/>
       <l:template name="intra-book" text="Bok ”%t”"/>
       <l:template name="intra-chapter" text="Kapitel&#160;%n ”%t”"/>
       <l:template name="intra-sect1" text="Section&#160;%n ”%t”"/>

--- a/suse2022-ns/common/l10n/zh_cn.xml
+++ b/suse2022-ns/common/l10n/zh_cn.xml
@@ -225,6 +225,7 @@
     -->
     <l:template name="intra-separator" text=", "/>
     <l:template name="intra-article" text="《%t》文章"/>
+    <l:template name="intra-appendix" text="附录&#160;%n 章 “%t”"/>
     <l:template name="intra-book" text="《%t》"/>
     <l:template name="intra-chapter" text="第&#160;%n 章 “%t”"/>
     <l:template name="intra-sect1" text="第&#160;%n 节 “%t”"/>

--- a/suse2022-ns/common/l10n/zh_tw.xml
+++ b/suse2022-ns/common/l10n/zh_tw.xml
@@ -214,6 +214,7 @@
      -->
     <l:template name="intra-separator" text=", "/>
     <l:template name="intra-article" text="《%t》文章"/>
+    <l:template name="intra-appendix" text="附录 %n 節「%t」"/>
     <l:template name="intra-book" text="《%t》"/>
     <l:template name="intra-chapter" text="第 %n 章「%t」"/>
     <l:template name="intra-sect1" text="第 %n 節「%t」"/>


### PR DESCRIPTION
For intra xref, the `intra-appendix` entry was missing in the l10n language files.