### PR TITLE
Add runinhead.title.end.punct

### DIFF
--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -203,6 +203,10 @@ task before
   </xsl:param>
 
   <xsl:param name="runinhead.default.title.end.punct">:</xsl:param>
+  <!-- Also include:
+    * Chinese colon U+FF1A (Fullwidth Colon)
+  -->
+  <xsl:param name="runinhead.title.end.punct">.!?:&#xff1a;</xsl:param>
 
   <!-- Should the content of programlisting|screen be syntactically highlighted? -->
   <xsl:param name="highlight.source" select="1" />


### PR DESCRIPTION
Julia reported that a `formalpara/title` contains two colons.

But they were two different colons: the one from the source code was U+FF1A ("Fullwidth Colon"), the other (automatically added) was U+003A (Colon).