### PR TITLE
DOCTEAM-1662: Disable Syntax highlighting

### DIFF
--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -209,7 +209,7 @@ task before
   <xsl:param name="runinhead.title.end.punct">.!?:&#xff1a;</xsl:param>
 
   <!-- Should the content of programlisting|screen be syntactically highlighted? -->
-  <xsl:param name="highlight.source" select="1" />
+  <xsl:param name="highlight.source" select="0" />
 
 
   <!-- From the DocBook XHTML stylesheet's "formal.xsl" -->

--- a/suse2022-ns/xhtml/verbatim.xsl
+++ b/suse2022-ns/xhtml/verbatim.xsl
@@ -15,17 +15,16 @@
     xmlns="http://www.w3.org/1999/xhtml"
     exclude-result-prefixes="exsl d">
 
-<xsl:template match="d:programlisting|d:screen|d:synopsis|d:computeroutput|d:userinput|d:literallayout">
+<xsl:template match="d:programlisting|d:screen">
   <xsl:variable name="supported" select="concat('|', $highlight.supported.languages, '|')"/>
   <xsl:variable name="language" select="translate(normalize-space(@language), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ|', 'abcdefghijklmnopqrstuvwxyz')"/>
-  
 
   <xsl:call-template name="check.screenlength"/>
 
   <div>
     <xsl:attribute name="class">
       <xsl:text>verbatim-wrap</xsl:text>
-      <xsl:if test="$language">
+      <xsl:if test="$language and $highlight.source != 0">
         <xsl:choose>
           <xsl:when test="contains($supported, concat('|', $language, '|'))">
             <xsl:text> highlight </xsl:text><xsl:value-of select="@language"/>
@@ -61,7 +60,14 @@
       <xsl:otherwise>plaintext</xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
-  <code class="{$language}"><xsl:apply-templates/></code>
+  <xsl:choose>
+    <xsl:when test="@language and $highlight.source != 0">
+      <code class="{$language}"><xsl:apply-templates/></code>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:apply-templates/>
+    </xsl:otherwise>
+  </xsl:choose>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
SH only works with raw text. As soon as you use additional inline tags inside <screen>, the highlight.js library removes them.

This is especially bad when you have callouts. They will completely vanish. :(

According to the highlight.js Wiki, it's a security measure to prevent XSS attacks. However, it can still be enabled on a case-by-case basis by setting `highlight.source=1` in the DC file as XSLT parameter if the writer ensures that `<screen>` contain only pure text and nothing else.

Related info:
https://github.com/highlightjs/highlight.js/wiki/security