### PR TITLE
Check for empty textobject/phrase

### DIFF
--- a/suse2022-ns/xhtml/graphics.xsl
+++ b/suse2022-ns/xhtml/graphics.xsl
@@ -928,7 +928,7 @@
   <xsl:variable name="alt.candidate">
     <xsl:choose>
       <!-- Try other first -->
-      <xsl:when test="../../d:textobject/d:phrase">
+      <xsl:when test="../../d:textobject/d:phrase[normalize-space() != '']">
           <xsl:apply-templates select="../../d:textobject/d:phrase/node()"/>
       </xsl:when>
       <xsl:when test="../../../d:caption[d:para]">


### PR DESCRIPTION
Fixes the "Link missing a text alternative" from Siteimprove.

If the textobject/phrase is empty, use figure/title or any other available title.