### PR TITLE
Raise contrast for platform markers

### DIFF
--- a/source-assets/styles2022/sass/custom/content-inline.sass
+++ b/source-assets/styles2022/sass/custom/content-inline.sass
@@ -48,9 +48,9 @@ strong
 
 .arch-arrow-start,
 .arch-arrow-end
-  background-color: $c_jungle
+  background-color: $c_mint
   border-radius: 3px
-  color: $c_white
+  color: $c_pine
   display: inline-block
   font-size: 14px
   height: 20px

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -2370,9 +2370,9 @@ strong {
 
 .arch-arrow-start,
 .arch-arrow-end {
-  background-color: #30ba78;
+  background-color: #90ebcd;
   border-radius: 3px;
-  color: white;
+  color: #0c322c;
   display: inline-block;
   font-size: 14px;
   height: 20px;

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -2624,9 +2624,9 @@ strong {
 
 .arch-arrow-start,
 .arch-arrow-end {
-  background-color: #30ba78;
+  background-color: #90ebcd;
   border-radius: 3px;
-  color: white;
+  color: #0c322c;
   display: inline-block;
   font-size: 14px;
   height: 20px;


### PR DESCRIPTION
Use $c_mint as background and $c_pine as text (ratio 9.91:1)

**Before**:
![Screenshot_20250305_125415](https://github.com/user-attachments/assets/b3a8a1a4-21a1-4274-a3be-ca1bcd021590)

**After**:
![Screenshot_20250305_125500](https://github.com/user-attachments/assets/c2dd029d-bad1-445e-8b95-8b654c49ea61)
