### PR TITLE
Make white stroke for SVG image (copy button)

### DIFF
--- a/source-assets/styles2022/sass/custom/content-mono-verbatim.sass
+++ b/source-assets/styles2022/sass/custom/content-mono-verbatim.sass
@@ -211,7 +211,7 @@ article
   > .clip-button:focus
     background-color: $c_dark_jungle
     color: $c_fog
-    background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="#{$c_fog_300_url}" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="#{$c_fog_300_url}" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>')
+    background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="white" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="white" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>')
 
   &.copy-success
     > div,

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -3050,7 +3050,7 @@ article a:hover code {
 .verbatim-wrap > .clip-button:focus {
   background-color: #008657;
   color: #efefef;
-  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="%23c0c2c4" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="%23c0c2c4" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>'); }
+  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="white" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="white" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>'); }
 
 .verbatim-wrap.copy-success > div,
 .verbatim-wrap.copy-success > pre {

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -3304,7 +3304,7 @@ article a:hover code {
 .verbatim-wrap > .clip-button:focus {
   background-color: #008657;
   color: #efefef;
-  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="%23c0c2c4" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="%23c0c2c4" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>'); }
+  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="white" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="white" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>'); }
 
 .verbatim-wrap.copy-success > div,
 .verbatim-wrap.copy-success > pre {


### PR DESCRIPTION
Related to #685

Color contras: pine : white = 4.61:1 (according to https://webaim.org/resources/contrastchecker/)

After the change:
![Screenshot_20250312_102925](https://github.com/user-attachments/assets/4fcad97e-08eb-4dcb-a2e1-295c921dffc6)

