### PR TITLE
Issue #686: Conditionally use syntax highlighting

### DIFF
--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -209,7 +209,7 @@ task before
   <xsl:param name="runinhead.title.end.punct">.!?:&#xff1a;</xsl:param>
 
   <!-- Should the content of programlisting|screen be syntactically highlighted? -->
-  <xsl:param name="highlight.source" select="0" />
+  <xsl:param name="highlight.source" select="1" />
 
 
   <!-- From the DocBook XHTML stylesheet's "formal.xsl" -->

--- a/suse2022-ns/xhtml/verbatim.xsl
+++ b/suse2022-ns/xhtml/verbatim.xsl
@@ -61,7 +61,12 @@
     </xsl:choose>
   </xsl:variable>
   <xsl:choose>
-    <xsl:when test="@language and $highlight.source != 0">
+    <!-- Only apply syntax highlighting, when we
+      * have a language attribute, and
+      * don't have child elements, and
+      * and $highlight.source = 1
+       -->
+    <xsl:when test="@language and not(*) and $highlight.source != 0">
       <code class="{$language}"><xsl:apply-templates/></code>
     </xsl:when>
     <xsl:otherwise>


### PR DESCRIPTION
This fix enables syntax highlighting and use the following algorithm:

1. If you have a language attribute, there are NO child elements, and the `$highlight.source = 1`, then use syntax highlighting.
2. Otherwise don't.

This helps to apply SH only on those cases where it can be really used.

Related: DOCTEAM-1662, #686