### PR TITLE
Color contrast links on procedure background

### DIFF
--- a/source-assets/styles2022/sass/colors.sass
+++ b/source-assets/styles2022/sass/colors.sass
@@ -1,0 +1,53 @@
+//
+// Colors
+//
+
+$c_white:         rgb(255, 255, 255)
+$c_black:         rgb(  0,   0,   0)
+
+$c_fog:           rgb(239, 239, 239)
+$c_fog_background: lighten($c_fog, 5%)  // #fcfcfc
+$c_fog_200:       rgb(222, 223, 224)
+$c_fog_300:       rgb(192, 194, 196)
+
+$c_pine:          rgb( 12,  50,  44)  // 0c322c
+$c_lighter_pine:  rgb( 2, 89, 55)     // 025937
+
+$c_jungle:        rgb( 48, 186, 120)  // 30ba78
+$c_dark_jungle:   rgb( 0, 134, 87)    // 008657
+$c_darker_jungle: rgb(2, 89, 55)      // 025937
+
+$c_midnight:      rgb( 25,  32, 114)  //
+$c_midnight_60:   rgb(117, 122, 167)  //
+$c_midnight_30:   rgb(187, 189, 212)  //
+
+$c_waterhole:     rgb( 36,  83, 255)  // 2453ff
+$c_waterhole_60:  rgb(128, 154, 247)  // 809af7
+$c_waterhole_30:  rgb(191, 203, 251)  // bfcbfb
+
+$c_persimmon:     rgb(254, 124,  63)  //
+$c_persimmon_60:  rgb(243, 178, 146)  //
+$c_persimmon_30:  rgb(249, 218, 200)  //
+
+$c_mint:          rgb(144, 235, 205)
+$c_mint_60:       rgb(199, 241, 227)
+$c_mint_30:       rgb(227, 248, 241)
+
+
+// special color variations
+$c_funky_persimmon_prelight: lighten($c_persimmon, 10%)
+$c_funky_jungle_prelight: lighten($c_jungle, 10%)
+$c_funky_pine_prelight: lighten($c_pine, 10%)
+
+$c_funky_darker_jungle: darken($c_jungle, 10%)
+
+// URL-encoded colors for background-image SVGs
+
+// FIXME: is there some way to do this via a mixin or so? redefining all
+//   those colors in hex leads to dumb duplication
+$s_uhash:                     '%23'
+$c_white_url:                 #{$s_uhash}fff
+$c_pine_url:                  #{$s_uhash}0c322c
+$c_jungle_url:                #{$s_uhash}30ba78
+$c_fog_300_url:               #{$s_uhash}c0c2c4
+$c_funky_darker_jungle_url:   #{$s_uhash}26915e

--- a/source-assets/styles2022/sass/custom/content-formal-informal.sass
+++ b/source-assets/styles2022/sass/custom/content-formal-informal.sass
@@ -1,6 +1,6 @@
 .complex-example .example-contents,
 .procedure-contents
-  background-color: lighten($c_fog, 2%)
+  background-color: $c_fog_background
   border-left: .2rem solid $c_fog_200
 
 .complex-example .example-contents

--- a/source-assets/styles2022/sass/custom/content-inline.sass
+++ b/source-assets/styles2022/sass/custom/content-inline.sass
@@ -127,7 +127,9 @@ p
 article
   a
     color: $c_dark_jungle
-    text-decoration: none
+    text-decoration: underline
+    text-decoration-thickness: 2px
+    text-underline-offset: 3px
 
     &:active,
     &:focus,
@@ -137,17 +139,17 @@ article
     &:visited:hover
       color: $c_dark_jungle
       text-decoration: underline
+      text-decoration-thickness: 3px
+      text-decoration-color: $c_pine
 
     &:visited
       color: $c_dark_jungle
 
-  p a 
-    color: $c_dark_jungle
-    text-decoration: underline
+  // p a
+  //   color: $c_dark_jungle
+  //   text-decoration: underline
+  //   text-decoration-thickness: 2px
 
-  .procedure-contents p a 
-    color: $c_lighter_pine
-    text-decoration: underline
 
 .free-id
   height: 0.01px

--- a/source-assets/styles2022/sass/style-new.sass
+++ b/source-assets/styles2022/sass/style-new.sass
@@ -15,44 +15,8 @@ $i_font_side_toc: .9rem
 $i_font_menu: .8rem
 $i_font_menu_mini: .7rem
 
+@import "colors.sass"
 
-// Colors
-
-$c_white:        rgb(255, 255, 255)
-$c_black:        rgb(  0,   0,   0)
-
-$c_fog:          rgb(239, 239, 239)
-$c_fog_200:      rgb(222, 223, 224)
-$c_fog_300:      rgb(192, 194, 196)
-
-$c_pine:         rgb( 12,  50,  44)
-$c_lighter_pine: rgb( 2, 89, 55)
-$c_jungle:       rgb( 48, 186, 120)
-$c_dark_jungle:  rgb( 0, 134, 87)
-
-$c_midnight:     rgb( 25,  32, 114)
-$c_midnight_60:  rgb(117, 122, 167)
-$c_midnight_30:  rgb(187, 189, 212)
-
-$c_waterhole:    rgb( 36,  83, 255)
-$c_waterhole_60: rgb(128, 154, 247)
-$c_waterhole_30: rgb(191, 203, 251)
-
-$c_persimmon:    rgb(254, 124,  63)
-$c_persimmon_60: rgb(243, 178, 146)
-$c_persimmon_30: rgb(249, 218, 200)
-
-$c_mint:         rgb(144, 235, 205)
-$c_mint_60:      rgb(199, 241, 227)
-$c_mint_30:      rgb(227, 248, 241)
-
-
-// special color variations
-$c_funky_persimmon_prelight: lighten($c_persimmon, 10%)
-$c_funky_jungle_prelight: lighten($c_jungle, 10%)
-$c_funky_pine_prelight: lighten($c_pine, 10%)
-
-$c_funky_darker_jungle: darken($c_jungle, 10%)
 
 // URL-encoded colors for background-image SVGs
 

--- a/source-assets/styles2022/sass/style.sass
+++ b/source-assets/styles2022/sass/style.sass
@@ -16,54 +16,7 @@ $i_font_menu: .8rem
 $i_font_menu_mini: .7rem
 
 
-// Colors
-
-$c_white:        rgb(255, 255, 255)
-$c_black:        rgb(  0,   0,   0)
-
-$c_fog:          rgb(239, 239, 239)
-$c_fog_200:      rgb(222, 223, 224)
-$c_fog_300:      rgb(192, 194, 196)
-
-$c_pine:         rgb( 12,  50,  44)
-$c_jungle:       rgb( 48, 186, 120)
-$c_lighter_pine: rgb( 2, 89, 55)
-$c_dark_jungle:  rgb( 0, 134, 87)
-
-$c_midnight:     rgb( 25,  32, 114)
-$c_midnight_60:  rgb(117, 122, 167)
-$c_midnight_30:  rgb(187, 189, 212)
-
-$c_waterhole:    rgb( 36,  83, 255)
-$c_waterhole_60: rgb(128, 154, 247)
-$c_waterhole_30: rgb(191, 203, 251)
-
-$c_persimmon:    rgb(254, 124,  63)
-$c_persimmon_60: rgb(243, 178, 146)
-$c_persimmon_30: rgb(249, 218, 200)
-
-$c_mint:         rgb(144, 235, 205)
-$c_mint_60:      rgb(199, 241, 227)
-$c_mint_30:      rgb(227, 248, 241)
-
-
-// special color variations
-$c_funky_persimmon_prelight: lighten($c_persimmon, 10%)
-$c_funky_jungle_prelight: lighten($c_jungle, 10%)
-$c_funky_pine_prelight: lighten($c_pine, 10%)
-
-$c_funky_darker_jungle: darken($c_jungle, 10%)
-
-// URL-encoded colors for background-image SVGs
-
-// FIXME: is there some way to do this via a mixin or so? redefining all
-//   those colors in hex leads to dumb duplication
-$s_uhash:                     '%23'
-$c_white_url:                 #{$s_uhash}fff
-$c_pine_url:                  #{$s_uhash}0c322c
-$c_jungle_url:                #{$s_uhash}30ba78
-$c_fog_300_url:               #{$s_uhash}c0c2c4
-$c_funky_darker_jungle_url:   #{$s_uhash}26915e
+@import "colors.sass"
 
 
 // header heights

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -2473,7 +2473,7 @@ article .procedure-contents p a {
 
 .complex-example .example-contents,
 .procedure-contents {
-  background-color: #f4f4f4;
+  background-color: #fcfcfc;
   border-left: 0.2rem solid #dedfe0; }
 
 .complex-example .example-contents {

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -2450,20 +2450,16 @@ p {
 
 article a {
   color: #008657;
-  text-decoration: none; }
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px; }
   article a:active, article a:focus, article a:hover, article a:visited:active, article a:visited:focus, article a:visited:hover {
     color: #008657;
-    text-decoration: underline; }
+    text-decoration: underline;
+    text-decoration-thickness: 3px;
+    text-decoration-color: #0c322c; }
   article a:visited {
     color: #008657; }
-
-article p a {
-  color: #008657;
-  text-decoration: underline; }
-
-article .procedure-contents p a {
-  color: #025937;
-  text-decoration: underline; }
 
 .free-id {
   height: 0.01px;

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -2704,20 +2704,16 @@ p {
 
 article a {
   color: #008657;
-  text-decoration: none; }
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px; }
   article a:active, article a:focus, article a:hover, article a:visited:active, article a:visited:focus, article a:visited:hover {
     color: #008657;
-    text-decoration: underline; }
+    text-decoration: underline;
+    text-decoration-thickness: 3px;
+    text-decoration-color: #0c322c; }
   article a:visited {
     color: #008657; }
-
-article p a {
-  color: #008657;
-  text-decoration: underline; }
-
-article .procedure-contents p a {
-  color: #025937;
-  text-decoration: underline; }
 
 .free-id {
   height: 0.01px;

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -2727,7 +2727,7 @@ article .procedure-contents p a {
 
 .complex-example .example-contents,
 .procedure-contents {
-  background-color: #f4f4f4;
+  background-color: #fcfcfc;
   border-left: 0.2rem solid #dedfe0; }
 
 .complex-example .example-contents {


### PR DESCRIPTION
This fix adjusts two parts:

* Adjust color contrast on procedure backgrounds
  Siteimprove reports for a link inside a procedure background a color contrast ratio of 4.2 : 1, but 4.5 : 1 is the minimum. Make the procedure background a little bit lighter.
* Make link and hover link more visible with underline thickness


