### PR TITLE
Improve color contrast when clicking Copy

### DIFF
--- a/source-assets/styles2022/sass/colors.sass
+++ b/source-assets/styles2022/sass/colors.sass
@@ -24,10 +24,14 @@ $c_midnight_30:   rgb(187, 189, 212)  //
 $c_waterhole:     rgb( 36,  83, 255)  // 2453ff
 $c_waterhole_60:  rgb(128, 154, 247)  // 809af7
 $c_waterhole_30:  rgb(191, 203, 251)  // bfcbfb
+$c_darker_waterhole: rgb(11, 65, 184) // #0b41b7
+$c_dark_waterhole: $c_midnight
 
-$c_persimmon:     rgb(254, 124,  63)  //
-$c_persimmon_60:  rgb(243, 178, 146)  //
-$c_persimmon_30:  rgb(249, 218, 200)  //
+$c_persimmon:     rgb(254, 124,  63)    //
+$c_persimmon_60:  rgb(243, 178, 146)    //
+$c_persimmon_30:  rgb(249, 218, 200)    //
+$c_darker_persimmon:  rgb(189, 51, 20)  // #bd3314
+$c_dark_persimmon:    rgb(71, 25, 13)   // #47190d
 
 $c_mint:          rgb(144, 235, 205)
 $c_mint_60:       rgb(199, 241, 227)

--- a/source-assets/styles2022/sass/custom/content-mono-verbatim.sass
+++ b/source-assets/styles2022/sass/custom/content-mono-verbatim.sass
@@ -216,4 +216,4 @@ article
   &.copy-success
     > div,
     > pre
-      background-color: $c_funky_pine_prelight
+      background-color: $c_darker_waterhole

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -3050,7 +3050,7 @@ article a:hover code {
 
 .verbatim-wrap.copy-success > div,
 .verbatim-wrap.copy-success > pre {
-  background-color: #165b50; }
+  background-color: #0b41b8; }
 
 @media screen {
   .hljs {

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -3304,7 +3304,7 @@ article a:hover code {
 
 .verbatim-wrap.copy-success > div,
 .verbatim-wrap.copy-success > pre {
-  background-color: #165b50; }
+  background-color: #0b41b8; }
 
 @media screen {
   .hljs {


### PR DESCRIPTION
* According to Siteimprove, color contrast ratio was 2.97:1 (minimum 4.5:1)
* Changed from $c_funky_pine_prelight (#26915E / RGB (38, 145, 94)) -> $c_darker_waterhole (#0b41b7 / RGB(11, 65, 184)). Ratio is 6.39:1 now.