### PR TITLE
Disable social media links

### DIFF
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -500,6 +500,7 @@
         </xsl:call-template>
       </div>
       <ul class="share">
+        <xsl:if test="$generate.socialmedia != 0">
         <li>
           <a id="_share-fb" href="#">
             <xsl:attribute name="title">
@@ -530,6 +531,7 @@
             <xsl:text> </xsl:text>
           </a>
         </li>
+        </xsl:if>
         <li>
           <a id="_share-mail" href="#">
             <xsl:attribute name="title">

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -373,6 +373,9 @@ task before
     </xsl:choose>
   </xsl:param>
 
+  <!-- Should social media (Facebook, LinkedIn, Twitter) be generated? -->
+  <xsl:param name="generate.socialmedia" select="0" />
+
   <!-- Allow generating "Give Feedback" section in sidebar. -->
   <xsl:param name="generate.give.feedback">0</xsl:param>
   <!-- Force generation of "Give Feedback" section, even if it may be empty in


### PR DESCRIPTION
According to our analytics, social media links aren't used a lot.

* Introduce `generate.socialmedia=0`
* Disable Facebook, Twitter, and LinkedIn

**Before**
![Screenshot_20250320_094522](https://github.com/user-attachments/assets/d526745c-bbf8-48ea-8506-7cbbab1aa6c4)


**After**
![Screenshot_20250320_094556](https://github.com/user-attachments/assets/24f1c630-c92a-45ba-96d9-19b06c7d72df)

