### PR TITLE
Fix color contrast for copy button

### DIFF
--- a/source-assets/styles2022/sass/custom/content-mono-verbatim.sass
+++ b/source-assets/styles2022/sass/custom/content-mono-verbatim.sass
@@ -189,12 +189,12 @@ article
     display: inline-block
     font-family: $f_sans
     font-size: 12px
-    height: 26px
-    line-height: 26px
+    height: 27px
+    line-height: 27px
     margin: 5px
     outline: none
     overflow: hidden
-    padding: 0 5px 0 25px
+    padding: 0 6px 0 26px
     text-align: left
     text-transform: uppercase
     position: absolute
@@ -209,9 +209,10 @@ article
 
   > .clip-button:hover,
   > .clip-button:focus
-    background-color: $c_dark_jungle
-    color: $c_fog
-    background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="white" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="white" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>')
+    font-weight: bold
+    background-color: $c_mint_30
+    color: $c_pine
+    background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="#{$c_pine_url}" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="#{$c_pine_url}" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>')
 
   &.copy-success
     > div,

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -3026,12 +3026,12 @@ article a:hover code {
   display: inline-block;
   font-family: SUSE, Suse, Roboto, sans-serif;
   font-size: 12px;
-  height: 26px;
-  line-height: 26px;
+  height: 27px;
+  line-height: 27px;
   margin: 5px;
   outline: none;
   overflow: hidden;
-  padding: 0 5px 0 25px;
+  padding: 0 6px 0 26px;
   text-align: left;
   text-transform: uppercase;
   position: absolute;
@@ -3044,9 +3044,10 @@ article a:hover code {
 
 .verbatim-wrap > .clip-button:hover,
 .verbatim-wrap > .clip-button:focus {
-  background-color: #008657;
-  color: #efefef;
-  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="white" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="white" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>'); }
+  font-weight: bold;
+  background-color: #e3f8f1;
+  color: #0c322c;
+  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="%230c322c" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="%230c322c" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>'); }
 
 .verbatim-wrap.copy-success > div,
 .verbatim-wrap.copy-success > pre {

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -3280,12 +3280,12 @@ article a:hover code {
   display: inline-block;
   font-family: SUSE, Suse, Roboto, sans-serif;
   font-size: 12px;
-  height: 26px;
-  line-height: 26px;
+  height: 27px;
+  line-height: 27px;
   margin: 5px;
   outline: none;
   overflow: hidden;
-  padding: 0 5px 0 25px;
+  padding: 0 6px 0 26px;
   text-align: left;
   text-transform: uppercase;
   position: absolute;
@@ -3298,9 +3298,10 @@ article a:hover code {
 
 .verbatim-wrap > .clip-button:hover,
 .verbatim-wrap > .clip-button:focus {
-  background-color: #008657;
-  color: #efefef;
-  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="white" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="white" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>'); }
+  font-weight: bold;
+  background-color: #e3f8f1;
+  color: #0c322c;
+  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" y="0px" x="0px" width="16" height="16"><path fill="%230c322c" d="m 14,1 v 12 h -2 v -1 h 1 V 2 H 5 V 2 H 4 V 1 Z" /><path fill="%230c322c" d="M 2,3 V 15 H 12 V 3 Z m 1,1 h 8 V 14 H 3 Z M 4,6 V 7 H 8 V 6 Z m 0,2 v 1 h 6 V 8 Z m 0,2 v 1 h 3 v -1 z" /></svg>'); }
 
 .verbatim-wrap.copy-success > div,
 .verbatim-wrap.copy-success > pre {


### PR DESCRIPTION
When hovering with the mouse over the "Copy" button, switch to bold font and set the color and background color accordingly:

**Normal**
![Screenshot_20250325_160216](https://github.com/user-attachments/assets/f96b430e-2b9b-476f-a635-1adbb7a07a2b)

**Activated**
`black`/`$c_fog`: [color contrast 18.26 : 1](https://colorcontrast.app/#fg=%23000&bg=%23efefef&level=aa&format=rgb&algo=WCAG2&filter=none)
![Screenshot_20250325_160252](https://github.com/user-attachments/assets/75dc216c-df63-41a8-b0f0-c1ff726f2b07)

**Hovered**
`$c_pine`/`$c_mint_30`: [color contrast 13.92 : 1](https://colorcontrast.app/#fg=rgb(12%2C%2050%2C%2044)&bg=%23fff&level=aa&format=rgb&algo=WCAG2&filter=none)
![Screenshot_20250325_160343](https://github.com/user-attachments/assets/c35e012b-9c82-4584-83a3-0956cd2e1c4f)

