### PR TITLE
Color contrast: Use c_lighter_pine for formal titles

### DIFF
--- a/source-assets/styles2022/sass/custom/content-formal-informal.sass
+++ b/source-assets/styles2022/sass/custom/content-formal-informal.sass
@@ -199,6 +199,7 @@ div.figure
   line-height: 120%
   text-align: left
   text-transform: uppercase
+  color: $c_lighter_pine
 
 
 .example-title,

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -2632,7 +2632,8 @@ div.figure {
   font-weight: normal;
   line-height: 120%;
   text-align: left;
-  text-transform: uppercase; }
+  text-transform: uppercase;
+  color: #025937; }
 
 .example-title,
 .itemizedlist-title,

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -2886,7 +2886,8 @@ div.figure {
   font-weight: normal;
   line-height: 120%;
   text-align: left;
-  text-transform: uppercase; }
+  text-transform: uppercase;
+  color: #025937; }
 
 .example-title,
 .itemizedlist-title,


### PR DESCRIPTION
Raise color contrast of all formal titles. Siteimprove reports

**Colour details**
* Contrast ratio 3.45:1
* Text colour: `#26915E` / RGB (38, 145, 94)
* Background colour: `#EFEFEF` / RGB (239, 239, 239)

Using `c_lighter_pine` (`#025937`) it raises the contrast ratio to 7.34 : 1.