### PR TITLE
Fix problem with GitHub URL &amp; masquerading

### DIFF
--- a/suse2022-ns/static/js/script-new.js
+++ b/suse2022-ns/static/js/script-new.js
@@ -157,16 +157,16 @@ function githubUrl(sectionName, permalink) {
     bugtrackerUrl +
     "?title=" +
     encodeURIComponent('[doc] Issue in "' + sectionName + '"') +
-    "&amp;body=" +
+    "&body=" +
     encodeURIComponent(body);
   if (ghAssignee) {
-    url += "&amp;assignee=" + encodeURIComponent(ghAssignee);
+    url += "&assignee=" + encodeURIComponent(ghAssignee);
   }
   if (ghMilestone) {
-    url += "&amp;milestone=" + encodeURIComponent(ghMilestone);
+    url += "&milestone=" + encodeURIComponent(ghMilestone);
   }
   if (ghLabels) {
-    url += "&amp;labels=" + encodeURIComponent(ghLabels);
+    url += "&labels=" + encodeURIComponent(ghLabels);
   }
 
   console.log("url=", url);

--- a/suse2022-ns/static/js/script-purejs.js
+++ b/suse2022-ns/static/js/script-purejs.js
@@ -146,16 +146,16 @@ function githubUrl(sectionName, permalink) {
     bugtrackerUrl +
     "?title=" +
     encodeURIComponent('[doc] Issue in "' + sectionName + '"') +
-    "&amp;body=" +
+    "&body=" +
     encodeURIComponent(body);
   if (ghAssignee) {
-    url += "&amp;assignee=" + encodeURIComponent(ghAssignee);
+    url += "&assignee=" + encodeURIComponent(ghAssignee);
   }
   if (ghMilestone) {
-    url += "&amp;milestone=" + encodeURIComponent(ghMilestone);
+    url += "&milestone=" + encodeURIComponent(ghMilestone);
   }
   if (ghLabels) {
-    url += "&amp;labels=" + encodeURIComponent(ghLabels);
+    url += "&labels=" + encodeURIComponent(ghLabels);
   }
 
   console.log("url=", url);

--- a/suse2022-ns/static/js/script.js
+++ b/suse2022-ns/static/js/script.js
@@ -149,15 +149,15 @@ function githubUrl(sectionName, permalink) {
   };
   var url = bugtrackerUrl
      + "?title=" + encodeURIComponent('[doc] Issue in "' + sectionName + '"')
-     + "&amp;body=" + encodeURIComponent(body);
+     + "&body=" + encodeURIComponent(body);
   if (ghAssignee) {
-    url += "&amp;assignee=" + encodeURIComponent(ghAssignee);
+    url += "&assignee=" + encodeURIComponent(ghAssignee);
   }
   if (ghMilestone) {
-    url += "&amp;milestone=" + encodeURIComponent(ghMilestone);
+    url += "&milestone=" + encodeURIComponent(ghMilestone);
   }
   if (ghLabels) {
-    url += "&amp;labels=" + encodeURIComponent(ghLabels);
+    url += "&labels=" + encodeURIComponent(ghLabels);
   }
 
   console.log("url=", url);


### PR DESCRIPTION
Meike reported, that for SBPs (and TRD) when clicking the "Report bug" button, the link is incomplete. Although it creates a GitHub issues, it's incomplete as no further body etc. is included.

After further inspection, it was a problem when building the URL. The ampersand was masked as in `&amp;body=...`. This should never be the case.

This fix corrects restores the ampersand and not `&amp;` for the JS files.