### PR TITLE
Adjust prev and next link in header

### DIFF
--- a/suse2022-ns/common/navigation.xsl
+++ b/suse2022-ns/common/navigation.xsl
@@ -36,34 +36,64 @@
     xmlns:l="http://docbook.sourceforge.net/xmlns/l10n/1.0"
     exclude-result-prefixes="exsl l t d">
 
+
   <!-- ===================================================== -->
   <xsl:template name="is.next.node.in.navig">
     <xsl:param name="next"/>
+    <xsl:param name="debug" select="false()" />
 
-    <xsl:variable name="next.book"
-      select="($next/ancestor-or-self::d:book |
-      $next/ancestor-or-self::d:article)[last()]"/>
-    <xsl:variable name="this.book"
-      select="(ancestor-or-self::d:book|ancestor-or-self::d:article)[last()]"/>
+    <xsl:variable name="next.book"    select="$next/ancestor-or-self::d:book" />
+    <xsl:variable name="next.article" select="$next/ancestor-or-self::d:article" />
     <!-- Compare the current "book" ID (be it really a book or an article)
        with the "next" or "previous" book or article ID
      -->
-    <xsl:value-of select="generate-id($this.book) = generate-id($next.book)"/>
+    <xsl:if test="boolean($debug)">
+      <xsl:message>is.next.node.in.navig:
+        Element:  <xsl:value-of select="local-name(.)"/>
+        next:     <xsl:value-of select="local-name($next)"/>
+        rootid:   <xsl:value-of select="concat(local-name($rootid.node), '/', $rootid)"/>
+        next.book:    <xsl:value-of select="$next.book/d:title"/>
+        next.article: <xsl:value-of select="$next.article/d:title"/>
+      </xsl:message>
+    </xsl:if>
+
+    <xsl:choose>
+      <xsl:when test="generate-id($rootid.node) = generate-id($next.article)"
+        >1</xsl:when>
+      <xsl:when test="generate-id($rootid.node) = generate-id($next.book)"
+        >1</xsl:when>
+      <xsl:otherwise>0</xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <!-- ===================================================== -->
   <xsl:template name="is.prev.node.in.navig">
     <xsl:param name="prev"/>
+    <xsl:param name="debug" select="false()" />
 
-    <xsl:variable name="prev.book"
-      select="($prev/ancestor-or-self::d:book |
-      $prev/ancestor-or-self::d:article)[last()]"/>
-    <xsl:variable name="this.book"
-      select="(ancestor-or-self::d:book|ancestor-or-self::d:article)[last()]"/>
+    <xsl:variable name="prev.book"    select="$prev/ancestor-or-self::d:book"/>
+    <xsl:variable name="prev.article" select="$prev/ancestor-or-self::d:article" />
+
     <!-- Compare the current "book" ID (be it really a book or an article)
        with the "next" or "previous" book or article ID
      -->
-    <xsl:value-of select="generate-id($this.book) = generate-id($prev.book)"/>
+    <xsl:if test="boolean($debug)">
+      <xsl:message>is.prev.node.in.navig:
+        Element:  <xsl:value-of select="local-name(.)"/>
+        prev:     <xsl:value-of select="local-name($prev)"/>
+        rootid:   <xsl:value-of select="$rootid"/>
+        prev.book:    <xsl:value-of select="$prev.book/d:title"/>
+        prev.article: <xsl:value-of select="$prev.article/d:title"/>
+      </xsl:message>
+    </xsl:if>
+
+    <xsl:choose>
+      <xsl:when test="generate-id($rootid.node) = generate-id($prev.article)"
+        >1</xsl:when>
+      <xsl:when test="generate-id($rootid.node) = generate-id($prev.book)"
+        >1</xsl:when>
+      <xsl:otherwise>0</xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <!-- ===================================================== -->
@@ -86,10 +116,18 @@
     <!-- Compare the current "book" ID (be it really a book or an article)
        with the "next" or "previous" book or article ID
      -->
-    <xsl:variable name="isnext"
-      select="generate-id($this.book) = generate-id($next.book)"/>
-    <xsl:variable name="isprev"
-      select="generate-id($this.book) = generate-id($prev.book)"/>
+    <xsl:variable name="isnext">
+      <!-- select="generate-id($this.book) = generate-id($next.book)" -->
+      <xsl:call-template name="is.next.node.in.navig">
+        <xsl:with-param name="next" select="$next"/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="isprev">
+      <!-- select="generate-id($this.book) = generate-id($prev.book)" -->
+      <xsl:call-template name="is.prev.node.in.navig">
+        <xsl:with-param name="prev" select="$prev"/>
+      </xsl:call-template>
+    </xsl:variable>
     <xsl:variable name="home" select="/*[1]"/>
     <xsl:variable name="up" select="parent::*"/>
     <xsl:if test="$debug">
@@ -118,6 +156,55 @@
          $target/ancestor-or-self::*[@xml:id=$rootid] = $this.ancestor
     -->
     <xsl:value-of select="count($target.in.ancestor)"/>
+  </xsl:template>
+
+  <xsl:template name="is.node.within.rootid">
+    <xsl:param name="node" select="NOT_A_NODE" />
+<!--    <xsl:param name="this" select="." />-->
+    <xsl:param name="debug" select="true()" />
+    <xsl:param name="this.rootid" select="$rootid" />
+    <!--  -->
+    <!--<xsl:variable name="this.ancestor"
+      select="($this/ancestor-or-self::d:article | $this/ancestor-or-self::d:book)[last()]"/>-->
+    <xsl:variable name="other.ancestor"
+      select="($node/ancestor-or-self::d:article | $node/ancestor-or-self::d:book)[last()]"/>
+    <xsl:variable name="rootid.node" select="key('id', $this.rootid)"/>
+    <!--  -->
+    <xsl:variable name="result">
+      <xsl:choose>
+      <xsl:when test="$this.rootid = ''">
+        <!-- If no $rootid is set, we don't need to handle prev/next differently.
+             All nodes are equally good.
+        -->
+        <xsl:value-of select="1"/>
+      </xsl:when>
+      <!--<xsl:when test="count($rootid.node | $other.ancestor) = 1">
+        <xsl:value-of select="true()"/>
+      </xsl:when>-->
+      <xsl:when test="local-name($rootid.node) = 'article' and local-name($other.ancestor) = 'article'">
+        <xsl:value-of select="count($rootid.node | $other.ancestor) -1"/><!--  -->
+      </xsl:when>
+      <xsl:otherwise>
+        <!--
+          As long as we have more than one node, we have two distinct nodes,
+          pointing to different elements.
+        -->
+        <xsl:value-of select="count($rootid.node | $other.ancestor) -1"/> <!--  &lt;= 1 -->
+      </xsl:otherwise>
+    </xsl:choose>
+    </xsl:variable>
+
+    <xsl:if test="boolean($debug)">
+      <xsl:message>is.node.within.rootid:
+      this.rootid:    <xsl:value-of select="$this.rootid"/>
+      rootid.node:    <xsl:value-of select="concat(name($rootid.node), '/', $rootid.node/@xml:id )"/>
+      <!--this.ancestor:  <xsl:value-of select="$this.ancestor/@xml:id"/>-->
+      other.ancestor: <xsl:value-of select="concat(name($other.ancestor), '/', $other.ancestor/@xml:id)"/>
+      union:          <xsl:value-of select="count($rootid.node | $other.ancestor)"/>
+      => result:      <xsl:value-of select="$result"/>
+      </xsl:message>
+    </xsl:if>
+    <xsl:value-of select="$result"/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/suse2022-ns/xhtml/chunk-common.xsl
+++ b/suse2022-ns/xhtml/chunk-common.xsl
@@ -370,5 +370,185 @@
     </xsl:if>
   </xsl:template>
 
+  <xsl:template name="html.head">
+    <xsl:param name="prev" select="/d:foo"/>
+    <xsl:param name="next" select="/d:foo"/>
+    <xsl:param name="debug" select="false()" />
+    <xsl:variable name="this" select="."/>
+    <xsl:variable name="home" select="/*[1]"/>
+    <xsl:variable name="up" select="parent::*"/>
+    <!--  -->
+    <xsl:variable name="next.book"    select="$next/ancestor-or-self::d:book" />
+    <xsl:variable name="next.article" select="$next/ancestor-or-self::d:article" />
+    <!--  -->
+    <xsl:variable name="prev.book"    select="$prev/ancestor-or-self::d:book"/>
+    <xsl:variable name="prev.article" select="$prev/ancestor-or-self::d:article" />
+    <!--  -->
+    <xsl:variable name="this.book"    select="$this/ancestor-or-self::d:book"/>
+    <xsl:variable name="this.article" select="$this/ancestor-or-self::d:article"/>
+    <!--  -->
+    <xsl:variable name="rootid.node" select="(key('id', $rootid) | /*)[last()]"/>
+    <xsl:variable name="candidate-prev">
+      <xsl:call-template name="is.prev.node.in.navig">
+        <xsl:with-param name="prev" select="$prev" />
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="candidate-next">
+      <xsl:call-template name="is.next.node.in.navig">
+        <xsl:with-param name="next" select="$next" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:if test="boolean($debug)">
+      <xsl:message>html.head:
+   rootid.node: <xsl:value-of select="concat(local-name($rootid.node), '/', $rootid, '|', generate-id($rootid.node))" />
+   this:        <xsl:value-of select="concat(local-name($this), '/', $this/@xml:id, '|', generate-id($this))"/>
+   prev:        <xsl:value-of select="concat(local-name($prev), '/', $prev/@xml:id, '|', generate-id($prev))"/>
+   prev.article <xsl:value-of select="generate-id($prev.article)"/>
+   prev.book    <xsl:value-of select="generate-id($prev.book)"/>
+   candidate.prev <xsl:value-of select="$candidate-prev"/>
+   next:        <xsl:value-of select="concat(local-name($next), '/', $next/@xml:id, '|', generate-id($next))"/>
+   next.article <xsl:value-of select="generate-id($next.article)"/>
+   next.book    <xsl:value-of select="generate-id($next.book)"/>
+   candidate.next <xsl:value-of select="$candidate-next"/>
+   $prev and candidate-prev:  <xsl:value-of select="$prev and $candidate-prev"/>
+   $next and candidate-next:  <xsl:value-of select="$next and $candidate-next"/><!--
+    count($rootid.node | $next.article) = <xsl:value-of select="count($rootid.node | $next.article)"/>
+    count($rootid.node | $next.book) = <xsl:value-of select="count($rootid.node | $next.book)"/>
+    count($rootid.node | $next.article | $next.book) = <xsl:value-of select="count($rootid.node | $next.article | $next.book)"/>
+   $rootid.node | $next.article or $rootid.node | $next.book = <xsl:value-of
+     select="count($rootid.node | $next.article) or count($rootid.node | $next.book)"/>-->
+      </xsl:message>
+    </xsl:if>
+
+
+    <head>
+      <xsl:call-template name="system.head.content"/>
+      <xsl:call-template name="head.content"/>
+
+      <!-- home link not valid in HTML5 -->
+      <xsl:if test="$home and $div.element != 'section'">
+        <link rel="home">
+          <xsl:attribute name="href">
+            <xsl:call-template name="href.target">
+              <xsl:with-param name="object" select="$home"/>
+            </xsl:call-template>
+          </xsl:attribute>
+          <xsl:attribute name="title">
+            <xsl:apply-templates select="$home" mode="object.title.markup.textonly"/>
+          </xsl:attribute>
+        </link>
+      </xsl:if>
+
+      <!-- up link not valid in HTML5 -->
+      <xsl:if test="$up and $div.element != 'section'">
+        <link rel="up">
+          <xsl:attribute name="href">
+            <xsl:call-template name="href.target">
+              <xsl:with-param name="object" select="$up"/>
+            </xsl:call-template>
+          </xsl:attribute>
+          <xsl:attribute name="title">
+            <xsl:apply-templates select="$up" mode="object.title.markup.textonly"/>
+          </xsl:attribute>
+        </link>
+      </xsl:if>
+
+      <xsl:if test="$prev and $candidate-prev != 0">
+        <xsl:if test="boolean($debug)">
+        <xsl:message>Generating $prev link (<xsl:value-of select="$candidate-prev"/>) to <xsl:value-of select="concat(local-name($prev), '/', $prev/@xml:id, '|', generate-id($prev))"/></xsl:message>
+        </xsl:if>
+        <link rel="prev">
+          <xsl:attribute name="href">
+            <xsl:call-template name="href.target">
+              <xsl:with-param name="object" select="$prev"/>
+            </xsl:call-template>
+          </xsl:attribute>
+          <xsl:attribute name="title">
+            <xsl:apply-templates select="$prev" mode="object.title.markup.textonly"/>
+          </xsl:attribute>
+        </link>
+      </xsl:if>
+
+      <xsl:if test="$next and $candidate-next != 0">
+        <xsl:if test="boolean($debug)">
+        <xsl:message>Generating $next link (<xsl:value-of select="$candidate-next"/>) to <xsl:value-of select="concat(local-name($next), '/', $next/@xml:id, '|', generate-id($next))"/></xsl:message>
+        </xsl:if>
+        <link rel="next">
+          <xsl:attribute name="href">
+            <xsl:call-template name="href.target">
+              <xsl:with-param name="object" select="$next"/>
+            </xsl:call-template>
+          </xsl:attribute>
+          <xsl:attribute name="title">
+            <xsl:apply-templates select="$next" mode="object.title.markup.textonly"/>
+          </xsl:attribute>
+        </link>
+      </xsl:if>
+
+      <xsl:if test="$html.extra.head.links != 0">
+        <xsl:for-each select="//d:part                             |//d:reference                             |//d:preface                             |//d:chapter                             |//d:article                             |//d:refentry                             |//d:appendix[not(parent::d:article)]|d:appendix                             |//d:glossary[not(parent::d:article)]|d:glossary                             |//d:index[not(parent::d:article)]|d:index">
+          <link rel="{local-name(.)}">
+            <xsl:attribute name="href">
+              <xsl:call-template name="href.target">
+                <xsl:with-param name="context" select="$this"/>
+                <xsl:with-param name="object" select="."/>
+              </xsl:call-template>
+            </xsl:attribute>
+            <xsl:attribute name="title">
+              <xsl:apply-templates select="." mode="object.title.markup.textonly"/>
+            </xsl:attribute>
+          </link>
+        </xsl:for-each>
+
+        <xsl:for-each select="d:section|d:sect1|d:refsection|d:refsect1">
+          <link>
+            <xsl:attribute name="rel">
+              <xsl:choose>
+                <xsl:when test="local-name($this) = 'section'                               or local-name($this) = 'refsection'">
+                  <xsl:value-of select="'subsection'"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="'section'"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:attribute>
+            <xsl:attribute name="href">
+              <xsl:call-template name="href.target">
+                <xsl:with-param name="context" select="$this"/>
+                <xsl:with-param name="object" select="."/>
+              </xsl:call-template>
+            </xsl:attribute>
+            <xsl:attribute name="title">
+              <xsl:apply-templates select="." mode="object.title.markup.textonly"/>
+            </xsl:attribute>
+          </link>
+        </xsl:for-each>
+
+        <xsl:for-each select="d:sect2|d:sect3|d:sect4|d:sect5|d:refsect2|d:refsect3">
+          <link rel="subsection">
+            <xsl:attribute name="href">
+              <xsl:call-template name="href.target">
+                <xsl:with-param name="context" select="$this"/>
+                <xsl:with-param name="object" select="."/>
+              </xsl:call-template>
+            </xsl:attribute>
+            <xsl:attribute name="title">
+              <xsl:apply-templates select="." mode="object.title.markup.textonly"/>
+            </xsl:attribute>
+          </link>
+        </xsl:for-each>
+      </xsl:if>
+
+      <!-- * if we have a legalnotice and user wants it output as a -->
+      <!-- * separate page and $html.head.legalnotice.link.types is -->
+      <!-- * non-empty, we generate a link or links for each value in -->
+      <!-- * $html.head.legalnotice.link.types -->
+      <xsl:if test="//d:legalnotice                   and not($generate.legalnotice.link = 0)                   and not($html.head.legalnotice.link.types = '')">
+        <xsl:call-template name="make.legalnotice.head.links"/>
+      </xsl:if>
+      <xsl:call-template name="user.head.content"/>
+    </head>
+  </xsl:template>
 
 </xsl:stylesheet>

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -539,4 +539,11 @@ task before
 
   <!-- Generates a separate file -->
   <xsl:param name="generate.revhistory.link" select="1"/>
+
+  <!--
+    Points to the root node when using $rootid. If $rootid is empty or points to
+    an invalid node, "/" (the root node) is used.
+  -->
+  <xsl:variable name="rootid.node" select="(key('id', $rootid) | /*)[last()]"/>
+
 </xsl:stylesheet>


### PR DESCRIPTION
# Problem

The DocBook XSL stylesheets create a "prev" and "next" link which looks like this:

```html
<link rel="prev" title="SAP Automation" href="article-sap-automation.html" />
<link rel="next" title="SAP Monitoring" href="article-sap-monitoring.html" />
```

However, this leads to problems as some of these links are not available (404 errors).


# Solution
This bug appears when you have a set with different books or articles and you only build one of them with the ROOTID feature. In that case, the other books before and after the current one are not built and as such not accessible.

The problem can be fixed if we check if the next and prev links are inside the realm of the ROOTID. If not, the links aren't generated.