### PR TITLE
Fix #713: Correct emphasis for Japanese

### DIFF
--- a/suse2022-ns/common/l10n/ja.xml
+++ b/suse2022-ns/common/l10n/ja.xml
@@ -75,9 +75,9 @@
 
    <l:context name="styles">
       <l:template name="person-name" text="first-last"/>
-      <l:template name="emphasis-open" text="「"/>
-      <l:template name="emphasis-close" text="」"/>
-      <l:template name="emphasis-style" text="" />
+      <l:template name="emphasis-open" text=""/>
+      <l:template name="emphasis-close" text=""/>
+      <l:template name="emphasis-style" text="bold" />
 
       <l:template name="example-label" text="&#20363; %n:"/>
       <l:template name="example-title" text="%t"/>

--- a/suse2022-ns/xhtml/inline.xsl
+++ b/suse2022-ns/xhtml/inline.xsl
@@ -84,6 +84,63 @@
     </xsl:if>
   </xsl:template>
 
+  <xsl:template match="d:emphasis">
+    <xsl:variable name="open">
+      <xsl:call-template name="gentext.template">
+        <xsl:with-param name="context" select="'styles'"/>
+        <xsl:with-param name="name" select="concat( local-name(),'-open')"/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="close">
+      <xsl:call-template name="gentext.template">
+        <xsl:with-param name="context" select="'styles'"/>
+        <xsl:with-param name="name" select="concat( local-name(),'-close')"/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="style">
+      <xsl:call-template name="gentext.template">
+        <xsl:with-param name="context" select="'styles'"/>
+        <xsl:with-param name="name" select="concat( local-name(),'-style')"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <span>
+      <xsl:copy-of select="$open"/>
+      <xsl:choose>
+        <xsl:when test="$style='bold' or @role='bold' or $style = 'strong' or @role='strong'">
+          <xsl:call-template name="inline.boldseq"/>
+        </xsl:when>
+        <xsl:when test="@role='underline'">
+          <span style="text-decoration: underline">
+            <xsl:call-template name="inline.charseq"/>
+          </span>
+        </xsl:when>
+        <xsl:when test="@role='strikethrough'">
+          <span style="text-decoration: line-through">
+            <xsl:call-template name="inline.charseq"/>
+          </span>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- How many regular emphasis ancestors does this element have -->
+          <xsl:variable name="depth" select="count(ancestor::d:emphasis
+            [not(contains(' bold strong underline strikethrough ', concat(' ', @role, ' ')))]
+            )"/>
+          <xsl:choose>
+            <xsl:when test="$depth mod 2 = 1">
+              <span>
+                <xsl:apply-templates/>
+              </span>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:call-template name="inline.italicseq"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:copy-of select="$close"/>
+    </span>
+  </xsl:template>
+
   <xsl:template match="d:keycap">
     <!-- See also Ticket#84 -->
     <xsl:choose>


### PR DESCRIPTION
* Change emphasis-style in styles (`common/l10n/ja.xml`)
* Add new d:emphasis template rule in HTML (`xhtml/inline.xsl`)