### PR TITLE
Add survey link to content pages

### DIFF
--- a/source-assets/styles2022/sass/custom/major-elements.sass
+++ b/source-assets/styles2022/sass/custom/major-elements.sass
@@ -120,6 +120,18 @@ main
       padding-left: 4rem !important
       padding-right: 4rem !important
 
+
+  .survey-link
+    background-color: $c_mint
+    padding: 16px
+    position: fixed
+    bottom: 16px
+    right: 16px
+    color: black
+    font-weight: 500
+    z-index: 3
+    text-decoration: none
+    
   .side-toc
     @extend .column
     @extend .is-2

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -1371,6 +1371,16 @@ main {
       main article {
         padding-left: 4rem !important;
         padding-right: 4rem !important; } }
+  main .survey-link {
+    background-color: #90ebcd;
+    padding: 16px;
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    color: black;
+    font-weight: 500;
+    z-index: 3;
+    text-decoration: none; }
   main .side-toc {
     overflow-y: auto;
     position: relative;

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -452,6 +452,7 @@
           <xsl:call-template name="generate.breadcrumbs.back"/>
           <xsl:apply-templates select="." mode="breadcrumbs"/>
         </div>
+        <xsl:call-template name="doc-survey"/>
       </div>
     </xsl:if>
   </xsl:template>
@@ -605,6 +606,14 @@
   <xsl:template name="qualtrics.rating">
     <xsl:if test="number($generate.qualtrics.div) != 0 and  $qualtrics.id != ''">
       <div id="{$qualtrics.id}"></div>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="doc-survey">
+    <xsl:if test="$doc.survey != 0">
+      <div class="docsurvey-wrapper">
+        <a class="survey-link" href="{$doc.survey.url}">Documentation survey</a>
+      </div>
     </xsl:if>
   </xsl:template>
 
@@ -1027,9 +1036,9 @@ if (window.location.protocol.toLowerCase() != 'file:') {
       <xsl:call-template name="give.feedback"/>
       <xsl:call-template name="share.and.print"/>
       <xsl:call-template name="qualtrics.rating"/>
-
       <xsl:text> </xsl:text>
     </aside>
+    <xsl:call-template name="doc-survey"/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -539,4 +539,10 @@ task before
 
   <!-- Generates a separate file -->
   <xsl:param name="generate.revhistory.link" select="1"/>
+
+  <!-- Should a button be generated on the right navigation? 0=no, 1=yes -->
+  <xsl:param name="doc.survey" select="0"></xsl:param>
+
+  <!-- The survey URL to be used. Change it accordingly -->
+  <xsl:param name="doc.survey.url">https://suselinux.fra1.qualtrics.com/jfe/form/SV_bEiGZbUNzLD8Tcy</xsl:param>
 </xsl:stylesheet>


### PR DESCRIPTION
# Request
A doc survey link is placed as a fixed link at the bottom of the right navigation pane.

Build it with daps and `--param="doc.survey=1"` (optionally with an additional `--stringparam="doc.survey.url=URL"`), it will produce:

![Screenshot_20250623_111347](https://github.com/user-attachments/assets/27342c7b-6ec5-4851-9a53-c408e75139e5)

