### PR TITLE
Update language switcher code & normalization

### DIFF
--- a/suse2022-ns/static/js/language-switcher.js
+++ b/suse2022-ns/static/js/language-switcher.js
@@ -1,0 +1,67 @@
+// Find all alternate hreflang link elements
+const hreflangLinks = document.querySelectorAll('link[rel="alternate"]');
+
+const hreflangToLangMapping = {
+  "en-us": "en",
+  "de-de": "de",
+  "fr-fr": "fr",
+  "es-es": "es",
+  "ja-jp": "ja",
+  "pt-br": "pt_BR",
+  "zh-cn": "zh_CN",
+  "ko-kr": "ko_KR",
+};
+
+// Create an object to hold the languages
+const languages = {};
+
+hreflangLinks.forEach((link) => {
+const hreflang = link.getAttribute("hreflang");
+const href = link.getAttribute("href");
+
+if (hreflang && hreflang !== "x-default") {
+  let label;
+  switch (hreflang.toLowerCase()) {
+    case "en-us":
+       label = "English";
+       break;
+    case "de-de":
+       label = "Deutsch";
+       break;
+    case "fr-fr":
+       label = "Français";
+       break;
+    case "es-es":
+       label = "Español";
+       break;
+    case "zh-cn":
+       label = "中文";
+       break;
+    case "ja-jp":
+       label = "日本語";
+       break;
+    case "ko-kr":
+       label = "한국어";
+       break;
+    case "pt-br":
+       label = "Português Brasileiro";
+       break;
+}
+
+let lang = hreflangToLangMapping[hreflang.toLowerCase()];
+  languages[lang] = {
+    label: label,
+    url: href,
+    };
+  }
+});
+
+// Get the current language
+const currentLang = document.documentElement.lang || "en";
+
+// Update the "shared-header" element
+const sharedHeader = document.querySelector("shared-header");
+if (sharedHeader) {
+    sharedHeader.setAttribute("language", currentLang);
+    sharedHeader.setAttribute("languages", JSON.stringify(languages));
+}

--- a/suse2022-ns/xhtml/chunk-common.xsl
+++ b/suse2022-ns/xhtml/chunk-common.xsl
@@ -230,24 +230,16 @@
     <xsl:variable name="lang-attr">
       <xsl:call-template name="get-lang-for-ssi" />
     </xsl:variable>
+    <xsl:variable name="node" select="(key('id', $rootid) | /*[1])[last()]"/>
+    <xsl:variable name="candidate.lang">
+      <xsl:call-template name="l10n.language">
+        <xsl:with-param name="target" select="$node"/>
+      </xsl:call-template>
+    </xsl:variable>
 
     <xsl:call-template name="user.preroot"/>
 
-    <html>
-      <xsl:attribute name="lang">
-        <xsl:choose>
-          <xsl:when test="$rootid">
-            <xsl:call-template name="l10n.language">
-              <xsl:with-param name="target" select="key('id', $rootid)"/>
-            </xsl:call-template>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:call-template name="l10n.language">
-              <xsl:with-param name="target" select="/*[1]"/>
-            </xsl:call-template>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:attribute>
+    <html lang="{$candidate.lang}" xml:lang="{$candidate.lang}">
       <xsl:call-template name="root.attributes" />
       <xsl:call-template name="html.head">
         <xsl:with-param name="prev" select="$prev" />
@@ -309,6 +301,9 @@
 
         <xsl:call-template name="user.footer.content" />
 
+        <xsl:if test="boolean($show.language-switcher)">
+          <xsl:call-template name="language-switcher" />
+        </xsl:if>
       </body>
     </html>
   </xsl:template>

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -753,6 +753,13 @@
 
   <!-- SUSE Header -->
   <xsl:template name="suse-header-header">
+    <xsl:call-template name="log.message">
+      <xsl:with-param name="level">hint</xsl:with-param>
+      <xsl:with-param name="context-desc">SUSE-Header</xsl:with-param>
+      <xsl:with-param name="message">
+        <xsl:text>Enabled SUSE Header head</xsl:text>
+      </xsl:with-param>
+    </xsl:call-template>
     <xsl:comment>SUSE Header head</xsl:comment>
     <script type="module">
      import { defineCustomElements, setAssetPath } from <xsl:value-of select='concat("&apos;", $suse.header.import.url, "&apos;")'/>;
@@ -760,23 +767,6 @@
      setAssetPath(<xsl:value-of select="concat('&quot;', $suse.header.assets.url, '&quot;')"/>);
    </script>
    <xsl:text>&#10;</xsl:text>
-   <xsl:if test="not(boolean($show.language-switcher))">
-    <script>var interval = setInterval(function () {
-   var sharedHeader = document.querySelector("shared-header");
-   var header = document.querySelector("header");
-
-   if (header) {
-     clearInterval(interval);
-   } else if (sharedHeader) {
-   var dropdown = document.querySelector('shared-header').shadowRoot.querySelector('suse-pl-dropdown');
-   if (dropdown) {
-     dropdown.style.display = "none";
-   }
-
-   clearInterval(interval);
-   }
-}, 100);</script>
-    </xsl:if>
   </xsl:template>
 
   <xsl:template name="suse-header-body">
@@ -788,9 +778,29 @@
       "zh_CN": { "label": "中文", "url": "https://documentation.suse.com/zh-cn/" },
       "pt_BR": { "label": "Português Brasileiro", "url": "https://documentation.suse.com/pt-br/" }
      }</xsl:variable>
+    <xsl:call-template name="log.message">
+      <xsl:with-param name="level">hint</xsl:with-param>
+      <xsl:with-param name="context-desc">SUSE-Header</xsl:with-param>
+      <xsl:with-param name="message">
+        <xsl:text>Enabled SUSE Header body (shared-header)</xsl:text>
+      </xsl:with-param>
+    </xsl:call-template>
     <shared-header language="en" languages='{translate($languages, "&#10;", "")}'>
       <xsl:text>&#x20;</xsl:text>
     </shared-header>
+  </xsl:template>
+
+
+  <xsl:template name="language-switcher">
+    <xsl:call-template name="log.message">
+        <xsl:with-param name="level">hint</xsl:with-param>
+        <xsl:with-param name="context-desc">LangSwitcher</xsl:with-param>
+        <xsl:with-param name="message">
+          <xsl:text>Enabled language switcher JS code</xsl:text>
+        </xsl:with-param>
+    </xsl:call-template>
+    <xsl:text>&#10;</xsl:text>
+    <script type="text/javascript" src="{$daps.header.js.languageswitcher}" />
   </xsl:template>
 
   <!-- ############################################################## -->
@@ -801,6 +811,7 @@
       <xsl:call-template name="handle-json-ld"/>
     </xsl:if>
   </xsl:template>
+
 
   <xsl:template match="*" mode="process.root">
     <xsl:param name="prev"/>
@@ -813,23 +824,13 @@
     <xsl:variable name="lang-attr">
       <xsl:call-template name="get-lang-for-ssi"/>
     </xsl:variable>
+    <xsl:variable name="node" select="(key('id', $rootid) | /*[1])[last()]"/>
     <xsl:variable name="candidate.lang">
-      <xsl:choose>
-        <xsl:when test="$rootid">
-          <xsl:call-template name="l10n.language">
-            <xsl:with-param name="target" select="key('id', $rootid)"/>
-          </xsl:call-template>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:call-template name="l10n.language">
-            <xsl:with-param name="target" select="/*[1]"/>
-          </xsl:call-template>
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:call-template name="l10n.language">
+        <xsl:with-param name="target" select="$node"/>
+      </xsl:call-template>
     </xsl:variable>
-
     <xsl:call-template name="user.preroot"/>
-    <xsl:call-template name="root.messages"/>
 
     <html lang="{$candidate.lang}" xml:lang="{$candidate.lang}">
       <xsl:call-template name="root.attributes"/>
@@ -887,6 +888,9 @@
 
         <xsl:call-template name="user.footer.content"/>
 
+        <xsl:if test="boolean($show.language-switcher)">
+          <xsl:call-template name="language-switcher" />
+        </xsl:if>
       </body>
     </html>
   </xsl:template>

--- a/suse2022-ns/xhtml/html.xsl
+++ b/suse2022-ns/xhtml/html.xsl
@@ -76,4 +76,23 @@ self-closing <script/> tags! -->
   </xsl:if>
 </xsl:template>
 
+
+  <xsl:template name="create-lang-attribute">
+    <xsl:param name="lang" />
+
+    <!-- match the attribute name to the output type -->
+    <xsl:choose>
+      <xsl:when test="$lang and $stylesheet.result.type = 'html'">
+        <xsl:attribute name="lang">
+          <xsl:value-of select="$lang"/>
+        </xsl:attribute>
+      </xsl:when>
+      <xsl:when test="$lang and $stylesheet.result.type = 'xhtml'">
+        <xsl:attribute name="xml:lang">
+          <xsl:value-of select="$lang"/>
+        </xsl:attribute>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -267,6 +267,8 @@ task before
   <xsl:param name="daps.header.js.custom">static/js/script-purejs.js</xsl:param>
   <xsl:param name="daps.header.js.highlight">static/js/highlight.js</xsl:param>
   <xsl:param name="daps.header.css.standard">static/css/style.css</xsl:param>
+  <!-- The language switcher code in the header -->
+  <xsl:param name="daps.header.js.languageswitcher">static/js/language-switcher.js</xsl:param>
 
   <!-- This list is intentionally quite strict (no aliases) to keep our documents
   consistent. -->


### PR DESCRIPTION
This PR adds:

* Update language switcher JS code and put it inside the file `suse2022-ns/static/js/language-switcher.js`
* Move Language switcher code before `</body>`
* Introduce JS filename to `$daps.header.js.languageswitcher` XSLT parameter
* Still use two-letter language code in root `<html>` tag for both single and chunked HTML

