### PR TITLE
Raise Cloudfront URLs (shared-header) to 1.5

### DIFF
--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -468,10 +468,10 @@ task before
   <xsl:param name="show.language-switcher" select="0" />
 
   <!-- The import URL of the SUSE header -->
-  <xsl:param name="suse.header.import.url">https://d12w0ryu9hjsx8.cloudfront.net/shared-header/1.2/shared-header.esm.js</xsl:param>
+  <xsl:param name="suse.header.import.url">https://d12w0ryu9hjsx8.cloudfront.net/shared-header/1.5/shared-header.esm.js</xsl:param>
 
   <!-- The assets URL of the SUSE header -->
-  <xsl:param name="suse.header.assets.url">https://d12w0ryu9hjsx8.cloudfront.net/shared-header/1.2/assets</xsl:param>
+  <xsl:param name="suse.header.assets.url">https://d12w0ryu9hjsx8.cloudfront.net/shared-header/1.5/assets</xsl:param>
 
   <!-- Should we generate a JSON-LD structure? 0=no, 1=yes -->
   <xsl:param name="generate.json-ld" select="1"/>


### PR DESCRIPTION
The two URLs in these parameters:

* `suse.header.assets.url`
* `suse.header.import.url`