### PR TITLE
Fix language for DC-*all deliverables

### DIFF
--- a/suse2022-ns/xhtml/chunk-common.xsl
+++ b/suse2022-ns/xhtml/chunk-common.xsl
@@ -233,11 +233,17 @@
     <xsl:variable name="node" select="(key('id', $rootid) | /*[1])[last()]"/>
     <xsl:variable name="candidate.lang">
       <xsl:call-template name="l10n.language">
-        <xsl:with-param name="target" select="$node"/>
+        <xsl:with-param name="target" select="$lang-scope"/>
       </xsl:call-template>
     </xsl:variable>
 
     <xsl:call-template name="user.preroot"/>
+
+    <xsl:message>chunk-element-content-html
+    element=<xsl:value-of select="local-name(.)"/>
+    xml:lang=<xsl:value-of select="$lang-scope/@xml:lang"/>
+    global=<xsl:value-of select="$node/@xml:lang"/>
+    </xsl:message>
 
     <html lang="{$candidate.lang}" xml:lang="{$candidate.lang}">
       <xsl:call-template name="root.attributes" />

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -826,10 +826,11 @@
     <xsl:variable name="lang-attr">
       <xsl:call-template name="get-lang-for-ssi"/>
     </xsl:variable>
+    <xsl:variable name="lang-scope" select="ancestor-or-self::*[@xml:lang][1]"/>
     <xsl:variable name="node" select="(key('id', $rootid) | /*[1])[last()]"/>
     <xsl:variable name="candidate.lang">
       <xsl:call-template name="l10n.language">
-        <xsl:with-param name="target" select="$node"/>
+        <xsl:with-param name="target" select="$lang-scope"/>
       </xsl:call-template>
     </xsl:variable>
     <xsl:call-template name="user.preroot"/>

--- a/suse2022-ns/xhtml/titlepage.xsl
+++ b/suse2022-ns/xhtml/titlepage.xsl
@@ -140,19 +140,11 @@
             <xsl:with-param name="base.name" select="$file" />
           </xsl:call-template>
         </xsl:variable>
+        <xsl:variable name="lang-scope" select="ancestor-or-self::*[@xml:lang][1]"/>
         <xsl:variable name="candidate.lang">
-          <xsl:choose>
-            <xsl:when test="$rootid">
-              <xsl:call-template name="l10n.language">
-                <xsl:with-param name="target" select="key('id', $rootid)"/>
-              </xsl:call-template>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:call-template name="l10n.language">
-                <xsl:with-param name="target" select="/*[1]"/>
-              </xsl:call-template>
-            </xsl:otherwise>
-          </xsl:choose>
+          <xsl:call-template name="l10n.language">
+            <xsl:with-param name="target" select="$lang-scope"/>
+          </xsl:call-template>
         </xsl:variable>
         <xsl:variable name="str.title" select="string($title)"/>
 


### PR DESCRIPTION
Fix that selects the nearest element that contains a `xml:lang` attribute. This helps to correct the wrong language attribute in HTML content for all `DC-*-all` deliverables.