### PR TITLE
Fix indentation on nested side toc entries

### DIFF
--- a/source-assets/styles2022/sass/custom/side-toc.sass
+++ b/source-assets/styles2022/sass/custom/side-toc.sass
@@ -95,6 +95,13 @@ $you_are_here_weight: 600
     @include m_tablet
       display: none !important
 
+  // side-toc indentation
+  &.side-toc
+    .toc
+      ul
+        li
+          ul
+            margin-left: 2em
 
 // Book ToC
 #_side-toc-overall

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -1528,6 +1528,9 @@ footer {
   #_side-toc-page .feedback {
     display: none !important; } }
 
+#_side-toc-page.side-toc .toc ul li ul {
+  margin-left: 2em; }
+
 #_side-toc-overall ol ol {
   background-color: #dedfe0;
   margin-bottom: 0;

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -1792,6 +1792,9 @@ body.disable-language-switcher #_utilitynav #_utilitynav-language {
   #_side-toc-page .feedback {
     display: none !important; } }
 
+#_side-toc-page.side-toc .toc ul li ul {
+  margin-left: 2em; }
+
 #_side-toc-overall ol ol {
   background-color: #dedfe0;
   margin-bottom: 0;


### PR DESCRIPTION
This fix improves indendation of sub-items on the side toc:

<img width="504" height="719" alt="image_720" src="https://github.com/user-attachments/assets/6c4a7493-baa7-436e-8552-217a6359f91f" />
