### PR TITLE
Add fallback date for JSON-LD and Dublin Core

### DIFF
--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -290,6 +290,13 @@
         <xsl:when test="$node/ancestor-or-self::*/d:info/d:revhistory/d:revision[1]/d:date">
           <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:revhistory/d:revision[1]/d:date)[last()])"/>
         </xsl:when>
+        <!-- Fallback -->
+        <xsl:when test="$node/ancestor-or-self::*/d:info/d:pubdate">
+          <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:pubdate)[last()])"/>
+        </xsl:when>
+        <xsl:when test="$node/ancestor-or-self::*/d:info/d:date">
+          <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:date)[last()])"/>
+        </xsl:when>
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="candidate-published">
@@ -297,6 +304,13 @@
         <!-- Select the nearest last revision date from the ancestor axis -->
         <xsl:when test="$node/ancestor-or-self::*/d:info/d:revhistory/d:revision[last()]/d:date">
           <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:revhistory/d:revision[last()]/d:date)[last()])"/>
+        </xsl:when>
+        <!-- Fallback: We don't distinguish between modified and published if we can't find a revhistory  -->
+        <xsl:when test="$node/ancestor-or-self::*/d:info/d:date">
+          <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:date)[last()])"/>
+        </xsl:when>
+        <xsl:when test="$node/ancestor-or-self::*/d:info/d:pubdate">
+          <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:pubdate)[last()])"/>
         </xsl:when>
       </xsl:choose>
     </xsl:variable>

--- a/suse2022-ns/xhtml/json-ld.xsl
+++ b/suse2022-ns/xhtml/json-ld.xsl
@@ -741,6 +741,13 @@
         <xsl:when test="$node/ancestor-or-self::*/d:info/d:revhistory/d:revision[1]/d:date">
           <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:revhistory/d:revision[1]/d:date)[last()])"/>
         </xsl:when>
+        <!-- Fallback -->
+        <xsl:when test="$node/ancestor-or-self::*/d:info/d:pubdate">
+          <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:pubdate)[last()])"/>
+        </xsl:when>
+        <xsl:when test="$node/ancestor-or-self::*/d:info/d:date">
+          <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:date)[last()])"/>
+        </xsl:when>
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="candidate-published">
@@ -748,6 +755,13 @@
         <!-- Select the nearest last revision date from the ancestor axis -->
         <xsl:when test="$node/ancestor-or-self::*/d:info/d:revhistory/d:revision[last()]/d:date">
           <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:revhistory/d:revision[last()]/d:date)[last()])"/>
+        </xsl:when>
+        <!-- Fallback -->
+        <xsl:when test="$node/ancestor-or-self::*/d:info/d:date">
+          <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:date)[last()])"/>
+        </xsl:when>
+        <xsl:when test="$node/ancestor-or-self::*/d:info/d:pubdate">
+          <xsl:value-of select="normalize-space(($node/ancestor-or-self::*/d:info/d:pubdate)[last()])"/>
         </xsl:when>
       </xsl:choose>
     </xsl:variable>


### PR DESCRIPTION
Prefer revhistory/revision/date, but use the following fallback:

* modified: pubdate, then date "_The date on which the CreativeWork was most recently modified or when the item's entry was modified_"
* published: date, then pubdate "_Date of first publication_"