### PR TITLE
Fix #763: Add French translation for note

### DIFF
--- a/suse2022-ns/common/l10n/fr.xml
+++ b/suse2022-ns/common/l10n/fr.xml
@@ -11,6 +11,10 @@
    <l:gentext key="Contributor"     text="Contributeur"/>
    <l:gentext key="Contributors"    text="Contributeurs"/>
 
+   <l:gentext key="NOTE" text="REMARQUE"/>
+   <l:gentext key="Note" text="Remarque"/>
+   <l:gentext key="note" text="remarque"/>
+
    <l:gentext key="admonseparator"  text="&#160;: "/>
    <l:gentext key="Date" text="Date"/>
    <l:gentext key="date" text="Date"/>


### PR DESCRIPTION
@jfaltenbacher: The original, upstream file is stored under `/usr/share/xml/docbook/stylesheet/nwalsh5/current/common/fr.xml`. The note comes from that (lines 89ff):

```xml
<l:gentext key="NOTE" text="NOTE"/>
<l:gentext key="Note" text="Note"/>
<l:gentext key="note" text="Note"/>
```

This change adds the correct translation into our files. I tried it with `doc-modular/l10n/fr-fr/DC-SLES-PXE-server` and this is the result:

<img width="644" height="135" alt="Screenshot_20251106_172550" src="https://github.com/user-attachments/assets/32595e57-07de-49dd-8fb8-db0f12fae778" />

