### PR TITLE
Use HTTPS instead of HTTP for schema.org

### DIFF
--- a/suse2022-ns/xhtml/json-ld.xsl
+++ b/suse2022-ns/xhtml/json-ld.xsl
@@ -19,7 +19,7 @@
      From doc-modular, DC-sudo-configure-superuser-privileges:
      <script type="application/ld+json">
       {
-        "@context": "http://schema.org",
+        "@context": "https://schema.org",
         "@type": [
           "TechArticle"
         ],
@@ -397,7 +397,7 @@
   <xsl:template name="generate-json-content">
     <xsl:param name="node"/>
     <xsl:text>{</xsl:text>
-    "@context": "http://schema.org",
+    "@context": "https://schema.org",
     "@type": ["TechArticle"],
     "image": "<xsl:value-of select="$json-ld-image-url"/>",
     <xsl:call-template name="json-ld-name">


### PR DESCRIPTION
Thanks to Joseph for finding it in the FAQ!

> "There is a general trend towards using 'https' more widely, and you can already write 'https://schema.org' in your structured data. We have migrated the schema.org site itself towards using https: as the default version of the site and our preferred form in examples. However 'http://schema.org' -based URLs in structured data markup will remain widely understood for the foreseeable future and there should be no urgency about migrating existing data. This is a lengthy way of saying that both 'https://schema.org' and 'http://schema.org' are fine."