### PR TITLE
Use documentation.suse.com for author.url

### DIFF
--- a/suse2022-ns/xhtml/json-ld.xsl
+++ b/suse2022-ns/xhtml/json-ld.xsl
@@ -734,7 +734,7 @@
       {
         "@type": "<xsl:value-of select="$json-ld-fallback-author-type"/>",
         "name": "<xsl:value-of select="$json-ld-fallback-author-name"/>",
-        "url": "<xsl:value-of select="$json-ld-fallback-author-logo"/>"
+        "url": "<xsl:value-of select="$json-ld-fallback-author-url"/>"
       }
     ],
       </xsl:when>


### PR DESCRIPTION
Discussed in our tools meeting today.

From a semantic point of view, linking to a logo is not the same as linking to an article that describes the author (=John). This is true. As we don't have such article, we link to our documentation site as a fallback. That's better than using a link to a logo.