### PR TITLE
Fix #748 Keep title in TOC together

### DIFF
--- a/suse2022-ns/fo/titlepage.templates.xsl
+++ b/suse2022-ns/fo/titlepage.templates.xsl
@@ -18,11 +18,12 @@
   %colors;
   %metrics;
 ]>
-<xsl:stylesheet exclude-result-prefixes="d"
-                  version="1.0"
+<xsl:stylesheet version="1.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:d="http://docbook.org/ns/docbook"
-  xmlns:fo="http://www.w3.org/1999/XSL/Format">
+  xmlns:fo="http://www.w3.org/1999/XSL/Format"
+  xmlns:exsl="http://exslt.org/common"
+  exclude-result-prefixes="exsl d">
 
   <xsl:include href="article.titlepage.templates.xsl"/>
   <xsl:include href="appendix.titlepage.templates.xsl"/>
@@ -104,4 +105,38 @@
 </xsl:template>
 
 
+  <xsl:template name="table.of.contents.titlepage">
+    <!-- Keep the title text and the TOC together -->
+    <fo:block keep-with-next.within-column="always">
+      <xsl:variable name="recto.content">
+        <xsl:call-template name="table.of.contents.titlepage.before.recto"/>
+        <xsl:call-template name="table.of.contents.titlepage.recto"/>
+      </xsl:variable>
+      <xsl:variable name="recto.elements.count">
+        <xsl:choose>
+          <xsl:when test="function-available('exsl:node-set')"><xsl:value-of select="count(exsl:node-set($recto.content)/*)"/></xsl:when>
+          <xsl:otherwise>1</xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+      <xsl:if test="(normalize-space($recto.content) != '') or ($recto.elements.count &gt; 0)">
+        <fo:block><xsl:copy-of select="$recto.content"/></fo:block>
+      </xsl:if>
+      <xsl:variable name="verso.content">
+        <xsl:call-template name="table.of.contents.titlepage.before.verso"/>
+        <xsl:call-template name="table.of.contents.titlepage.verso"/>
+      </xsl:variable>
+      <xsl:variable name="verso.elements.count">
+        <xsl:choose>
+          <xsl:when test="function-available('exsl:node-set')"><xsl:value-of select="count(exsl:node-set($verso.content)/*)"/></xsl:when>
+          <xsl:when test="contains(system-property('xsl:vendor'), 'Apache Software Foundation')">
+            <!--Xalan quirk--><xsl:value-of select="count(exsl:node-set($verso.content)/*)"/></xsl:when>
+          <xsl:otherwise>1</xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+      <xsl:if test="(normalize-space($verso.content) != '') or ($verso.elements.count &gt; 0)">
+        <fo:block><xsl:copy-of select="$verso.content"/></fo:block>
+      </xsl:if>
+      <xsl:call-template name="table.of.contents.titlepage.separator"/>
+    </fo:block>
+  </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Depending on the amount of text, sometimes the title text "Content" of a TOC appears on one page and the entire list on the next one.

This fix keeps them together.