### PR TITLE
Fix baseline shift for zh-cn language <systemitem>

### DIFF
--- a/suse2022-ns/fo/inline.xsl
+++ b/suse2022-ns/fo/inline.xsl
@@ -70,9 +70,14 @@
     <xsl:if test="$mono-verbatim-ancestor = 1 or
                   ancestor::d:title[not(parent::d:formalpara)]">1</xsl:if>
   </xsl:variable>
+  <xsl:variable name="lang" select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+  <xsl:variable name="is-zh" select="starts-with($lang,'zh')"/>
 
   <fo:inline>
    <xsl:if test="$lighter-formatting != 1">
+    <xsl:if test="$is-zh">
+      <xsl:attribute name="baseline-shift">0.061em</xsl:attribute>
+    </xsl:if>
     <!-- FIXME: fix grayscale -->
     <xsl:attribute name="border-bottom">&thinline;mm solid &c_fog_300;</xsl:attribute>
     <xsl:attribute name="padding-bottom">0.1em</xsl:attribute>


### PR DESCRIPTION
Added `baseline-shift` attribute and align it with the the rest. This is the result:

<img width="652" height="141" alt="Screenshot_20260130_162647" src="https://github.com/user-attachments/assets/a7a49aab-50ad-4467-a1a5-b0b2a7d6d4ee" />
