### PR TITLE
SUVA / AskGeeko integration

### DIFF
--- a/source-assets/styles2022/sass/custom/major-elements-new.sass
+++ b/source-assets/styles2022/sass/custom/major-elements-new.sass
@@ -3,7 +3,6 @@ $c_side_toc_background: $c_fog
 html,
 body
   font-size: 18px
-  height: 100%
   scroll-behavior: smooth
 
 

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -1285,7 +1285,6 @@ th {
 html,
 body {
   font-size: 18px;
-  height: 100%;
   scroll-behavior: smooth; }
 
 body {

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -407,6 +407,20 @@
       <xsl:comment>END WEBSITE FEEDBACK SNIPPET</xsl:comment>
     <xsl:text>&#10;</xsl:text>
   </xsl:if>
+  <xsl:if test="number($generate.suva) != 0">
+    <xsl:comment>SUVA/AskGeeko start</xsl:comment>
+    <xsl:comment><xsl:value-of select="$suva.copyright"/></xsl:comment>
+    <xsl:text>&#10;</xsl:text>
+    <script type="text/javascript" src="{$suva.url}/Allow/an.js?{$suva.id}"><xsl:comment /></script>
+    <xsl:text>&#10;</xsl:text>
+    <script type="text/javascript" src="{$suva.url}/js/index.js?q=gAAAAABp3JBN9VuEJTi5tFafLIMwgMkCPdJS3Qm56lSYx93ir3Twt9hgSvd3OHEt6-nYfSbY3yHq0Zv8PRPsSy4nbqZiaJ4cZvRc6ItVZdvwz9Urf35cH6OUyPOwdA0phlS-zVIznQ2rWW438p-91NlTHuxJuOFpnA=="><xsl:comment /></script>
+    <xsl:text>&#10;</xsl:text>
+    <link rel="stylesheet" href="{$suva.css.url}"><xsl:comment /></link>
+    <xsl:text>&#10;</xsl:text>
+    <div id="searchUnifyChatbot"><xsl:comment /></div>
+    <xsl:text>&#10;</xsl:text>
+    <xsl:comment>SUVA/AskGeeko end</xsl:comment>
+  </xsl:if>
 </xsl:template>
 
 

--- a/suse2022-ns/xhtml/param.xsl
+++ b/suse2022-ns/xhtml/param.xsl
@@ -549,4 +549,12 @@ task before
 
   <!-- The survey URL to be used. Change it accordingly -->
   <xsl:param name="doc.survey.url">https://suselinux.fra1.qualtrics.com/jfe/form/SV_bEiGZbUNzLD8Tcy</xsl:param>
+
+  <!-- SUVA engine -->
+  <xsl:param name="generate.suva" select="0" />
+  <xsl:param name="suva.id">c485cb3c-93d4-4942-99e8-91f3b8ca5636</xsl:param>
+  <xsl:param name="suva.url">https://suse.searchunify.com/suva-resources/suva_clients_custom/<xsl:value-of select="$suva.id"/></xsl:param>
+  <xsl:param name="suva.css.url" select="concat($suva.url, '/css/index.css')" />
+  <xsl:param name="suva.copyright">searchUnifyChatbot ("Ask Geeko") copyright 2024 Grazitti Interactive - All Rights Reserved. NOTICE: All information contained herein is, and remains the property of Grazitti Interactive and its suppliers, if any. The intellectual and technical concepts contained herein are proprietary to Grazitti Interactive and its suppliers and may be covered by India, U.S. and Foreign Patents, patents in process, and are protected by trade secret or copyright law. Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained from Grazitti Interactive.</xsl:param>
+
 </xsl:stylesheet>


### PR DESCRIPTION
## Background

This change integrates an "Ask Geeko" field that allows to ask Geeko questions about our documentation.

## New parameters
* `suva.url`: The "base" URL without a trailing slash. This URL is used to create different URLs like "`$suva.url/Allow/...`" and "`$suva.url/js/index.j?...`". The URL already contains the SUVA ID.
* `suva.id`: A string that contains the SUVA ID
* `suva.resource.url`: The complete URL to SUVA's CSS file
* `suva.copyright`: A copyright notice that is added as a HTML comment.
* `generate.suva`: a boolean or 0/1 to activate SUVA; default 0 (=off)