### PR TITLE
Doc survey link

### DIFF
--- a/source-assets/styles2022/sass/custom/major-elements-new.sass
+++ b/source-assets/styles2022/sass/custom/major-elements-new.sass
@@ -223,23 +223,23 @@ footer
   background-color: $c_pine
   position: relative
 
-.docsurvey-wrapper {
+.docsurvey-wrapper 
   background-color: $c_dark_jungle
   font-size: 16px
   margin-top: 16px
   padding-block: 8px
   padding-inline: 8px
   width: fit-content
-}
 
-.docsurvey-wrapper a.survey-link {
+
+.docsurvey-wrapper a.survey-link 
   color: #fff !important
   text-decoration: none
-}
 
-.docsurvey-wrapper a.survey-link:hover {
+
+.docsurvey-wrapper a.survey-link:hover
   background-color: inherit !important
-}
+
  
 
 @include m_tablet

--- a/source-assets/styles2022/sass/custom/major-elements-new.sass
+++ b/source-assets/styles2022/sass/custom/major-elements-new.sass
@@ -223,7 +223,24 @@ footer
   background-color: $c_pine
   position: relative
 
+.docsurvey-wrapper {
+  background-color: $c_dark_jungle
+  font-size: 16px
+  margin-top: 16px
+  padding-block: 8px
+  padding-inline: 8px
+  width: fit-content
+}
 
+.docsurvey-wrapper a.survey-link {
+  color: #fff !important
+  text-decoration: none
+}
+
+.docsurvey-wrapper a.survey-link:hover {
+  background-color: inherit !important
+}
+ 
 
 @include m_tablet
   main

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -1421,6 +1421,21 @@ footer {
   background-color: #0c322c;
   position: relative; }
 
+.docsurvey-wrapper {
+  background-color: #008657;
+  font-size: 16px;
+  margin-top: 16px;
+  padding-block: 8px;
+  padding-inline: 8px;
+  width: fit-content; }
+
+.docsurvey-wrapper a.survey-link {
+  color: #fff !important;
+  text-decoration: none; }
+
+.docsurvey-wrapper a.survey-link:hover {
+  background-color: inherit !important; }
+
 @media screen and (max-width: 1024px) {
   main .side-toc#_side-toc-overall {
     display: block;

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -1077,6 +1077,7 @@ if (window.location.protocol.toLowerCase() != 'file:') {
 
   <xsl:template name="side.toc.page">
     <aside id="_side-toc-page" class="side-toc">
+      <xsl:call-template name="doc-survey"/>
       <!-- FIXME suse22: Does not work correctly for single-page sets & books
       (but does work for articles). So just disable it in that case for now and
       focus on chunked HTML ... -->
@@ -1113,7 +1114,6 @@ if (window.location.protocol.toLowerCase() != 'file:') {
       <xsl:call-template name="qualtrics.rating"/>
       <xsl:text> </xsl:text>
     </aside>
-    <xsl:call-template name="doc-survey"/>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
This PR contains:

* Move the doc survey link to the top right navigation side
* Adjust SASS/CSS


<img width="1344" height="266" alt="Bildschirmfoto_20260603_092123" src="https://github.com/user-attachments/assets/ba13b9cd-d948-4f3f-a450-a7e37775660f" />

