### PR TITLE
Fix survey button in single HTML

### DIFF
--- a/source-assets/styles2022/sass/custom/content-title.sass
+++ b/source-assets/styles2022/sass/custom/content-title.sass
@@ -62,7 +62,6 @@ h1:has(.title-container)
 
 
 .single .appendix,
-.single .article,
 .single .bibliography,
 .single .chapter,
 .single .part,

--- a/suse2022-ns/static/css/style-new.css
+++ b/suse2022-ns/static/css/style-new.css
@@ -2101,7 +2101,6 @@ h1:has(.title-container) {
   width: 100%; }
 
 .single .appendix .title,
-.single .article .title,
 .single .bibliography .title,
 .single .chapter .title,
 .single .part .title,

--- a/suse2022-ns/static/css/style.css
+++ b/suse2022-ns/static/css/style.css
@@ -2330,7 +2330,6 @@ h1:has(.title-container) {
   width: 100%; }
 
 .single .appendix .title,
-.single .article .title,
 .single .bibliography .title,
 .single .chapter .title,
 .single .part .title,

--- a/suse2022-ns/xhtml/docbook.xsl
+++ b/suse2022-ns/xhtml/docbook.xsl
@@ -496,7 +496,6 @@
           <xsl:call-template name="generate.breadcrumbs.back"/>
           <xsl:apply-templates select="." mode="breadcrumbs"/>
         </div>
-        <xsl:call-template name="doc-survey"/>
       </div>
     </xsl:if>
   </xsl:template>


### PR DESCRIPTION
For the single HTML output, the survey button link appears twice: on the right side in the navigation pane and inside the breadcrumb under the header. The latter is wrong.