### PR TITLE
Fix #813: Make TRD PDF similar to HTML

### DIFF
--- a/trd/fo/article.titlepage.templates.xsl
+++ b/trd/fo/article.titlepage.templates.xsl
@@ -59,9 +59,14 @@
     <!-- product -->
     <fo:block space-before="3cm">
       <xsl:if test="d:info/d:productname">
-        <fo:block role="productname">
-          <xsl:apply-templates select="d:info/d:productname[1]" mode="article.titlepage.recto.auto.mode"/>
+        <fo:block role="productname" text-align="start"
+          font-size="{&xx-large; * $sans-fontsize-adjust}pt" space-after="0.5em">
+          <fo:inline background-color="&c_jungle;" color="white"
+            padding="0.3em 0.3em 0.1em 0.3em">
+            <xsl:call-template name="version.info.headline" />
+          </fo:inline>
         </fo:block>
+        <!--          <xsl:apply-templates select="d:info/d:productname[1]" mode="article.titlepage.recto.auto.mode"/>-->
       </xsl:if>
 
     <!-- Title -->

--- a/trd/fo/article.titlepage.templates.xsl
+++ b/trd/fo/article.titlepage.templates.xsl
@@ -39,6 +39,7 @@
         </fo:table-cell>
         <fo:table-cell text-align="right" color="&c_jungle;">
           <fo:block font-size="&x-large;pt" hyphenate="false">
+            <xsl:message>##########</xsl:message>
             <xsl:choose>
               <xsl:when test="$json-ld-seriesname != ''">
                 <xsl:value-of select="$json-ld-seriesname"/>
@@ -104,25 +105,30 @@
       <fo:external-graphic content-width="100%" src="{$titlepage.logo.image}" />
     </fo:block>
 
-    <!-- Platform specific -->
-    <fo:block space-before="2em" text-align="right" font-size="&normal;pt">
-      <xsl:apply-templates select="d:info/d:meta[@name='platform']" mode="article.titlepage.recto.auto.mode"/>
-    </fo:block>
-
     <!-- Authors -->
     <fo:block space-before="4em" font-size="&normal;pt">
+      <fo:block font-weight="bold" text-align="left">
+        <xsl:call-template name="gentext">
+          <xsl:with-param name="key">Authors</xsl:with-param>
+      </xsl:call-template>
+      </fo:block>
       <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
         select="d:info/d:authorgroup" />
       <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
         select="d:info/d:author[1]" />
     </fo:block>
 
-    <fo:block-container absolute-position="absolute" top="{$page.height.portrait} * 0.78">
+    <!-- Platform specific -->
+    <fo:block space-before="4em" text-align="left" font-size="&normal;pt">
+      <xsl:apply-templates select="d:info/d:meta[@name='platform']" mode="article.titlepage.recto.auto.mode"/>
+    </fo:block>
+
+    <!--<fo:block-container absolute-position="absolute" top="{$page.height.portrait} * 0.78">
       <fo:block>
         <xsl:apply-templates mode="article.titlepage.recto.auto.mode"
           select="d:info/d:cover[d:mediaobject]" />
       </fo:block>
-    </fo:block-container>
+    </fo:block-container>-->
   </xsl:template>
 
   <xsl:template name="article.titlepage.separator">
@@ -214,7 +220,7 @@
 
 
   <xsl:template match="d:authorgroup" mode="article.titlepage.recto.auto.mode">
-    <fo:block text-align="outside">
+    <fo:block text-align="left">
       <xsl:for-each select="d:author">
         <fo:block>
           <xsl:apply-templates select="." mode="authorgroup">

--- a/trd/fo/book.titlepage.templates.xsl
+++ b/trd/fo/book.titlepage.templates.xsl
@@ -90,11 +90,6 @@
         content-width="100%" src="{$titlepage.logo.image}" />
     </fo:block>
 
-    <!-- Platform specific -->
-    <fo:block space-before="2em" text-align="right" font-size="&normal;pt">
-      <xsl:apply-templates select="d:info/d:meta[@name='platform']" mode="book.titlepage.recto.auto.mode"/>
-    </fo:block>
-
     <!-- Authors -->
     <fo:block space-before="4em" font-size="&normal;pt">
       <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
@@ -103,13 +98,18 @@
         select="d:info/d:author[1]" />
     </fo:block>
 
+    <!-- Platform specific -->
+    <fo:block space-before="2em" text-align="left" font-size="&normal;pt">
+      <xsl:apply-templates select="d:info/d:meta[@name='platform']" mode="book.titlepage.recto.auto.mode"/>
+    </fo:block>
+
     <!-- Cover Icons -->
-    <fo:block-container absolute-position="absolute" top="{$page.height.portrait} * 0.78">
+    <!--<fo:block-container absolute-position="absolute" top="{$page.height.portrait} * 0.78">
       <fo:block>
         <xsl:apply-templates mode="book.titlepage.recto.auto.mode"
           select="d:info/d:cover[d:mediaobject]" />
       </fo:block>
-    </fo:block-container>
+    </fo:block-container>-->
   </xsl:template>
 
 
@@ -169,7 +169,7 @@
   </xsl:template>
 
   <xsl:template match="d:authorgroup" mode="book.titlepage.recto.auto.mode">
-    <fo:block text-align="outside" font-family="{$sans-stack}">
+    <fo:block text-align="left" font-family="{$sans-stack}">
       <xsl:for-each select="d:author">
         <fo:block>
           <xsl:apply-templates select="." mode="authorgroup">

--- a/trd/fo/docbook.xsl
+++ b/trd/fo/docbook.xsl
@@ -33,5 +33,5 @@
   <xsl:include href="param.xsl"/>
   <xsl:include href="article.titlepage.templates.xsl"/>
   <xsl:include href="book.titlepage.templates.xsl"/>
-
+  <xsl:include href="header.xsl"/>
 </xsl:stylesheet>

--- a/trd/fo/header.xsl
+++ b/trd/fo/header.xsl
@@ -1,0 +1,130 @@
+<!--
+
+-->
+
+<xsl:stylesheet  version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:fo="http://www.w3.org/1999/XSL/Format"
+  xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:exsl="http://exslt.org/common"
+  xmlns="http://www.w3.org/1999/xhtml"
+  exclude-result-prefixes="exsl d">
+
+
+  <xsl:template name="product.name">
+    <!-- One can use role="abbrev" to additionally store a short version
+    of the productname. This is helpful to make the best of the space
+    available in the living column titles of the FO version.
+    In general, we want the long/official version, though. Dito for the
+    productnumber below. -->
+    <xsl:param name="prefer-abbreviation" select="0"/>
+    <xsl:variable name="meta.nodes" select="d:info/d:meta|ancestor::*/d:info/d:meta"/>
+    
+    <!--
+      First we search for all productname[@role='abbrev'], starting in the nearest node followed
+      by its ancestors.
+    -->
+    <xsl:choose>
+      <xsl:when test="$meta.nodes[@name='bugtracker']/d:phrase[@name='productname'] and $prefer-abbreviation = 0">/
+        <xsl:apply-templates select="$meta.nodes[@name='bugtracker']/d:phrase[@name='productname'][last()]" mode="meta"/>
+      </xsl:when>
+      <xsl:when test="*/d:productname[@role='abbrev'] and $prefer-abbreviation = 1">
+        <xsl:apply-templates select="(*/d:productname[@role='abbrev'])[last()]"/>
+      </xsl:when>
+      <xsl:when test="ancestor-or-self::*/*/d:productname[@role='abbrev'] and $prefer-abbreviation = 1">
+        <xsl:apply-templates select="(ancestor-or-self::*/*/d:productname[@role='abbrev'])[last()]"/>
+      </xsl:when>
+      <xsl:when test="$meta.nodes[@name='productname']/d:productname">
+        <xsl:apply-templates select="$meta.nodes[@name='productname']/d:productname[1]" />
+      </xsl:when>
+      <xsl:when test="*/d:productname[not(@role='abbrev')]">
+        <xsl:apply-templates select="(*/d:productname[not(@role='abbrev')])[last()]"/>
+      </xsl:when>
+      <xsl:when test="ancestor-or-self::*/*/d:productname[not(@role='abbrev')]">
+        <xsl:apply-templates select="(ancestor-or-self::*/*/d:productname[not(@role='abbrev')])[last()]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="(ancestor-or-self::*/*/d:productname)[last()]"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+
+  <xsl:template name="product.number">
+    <!-- See comment in product.name... -->
+    <xsl:param name="prefer-abbreviation" select="0"/>
+    <xsl:variable name="meta.nodes" select="d:info/d:meta|ancestor::*/d:info/d:meta"/>
+    
+    <!-- FIXME: This choose mechanism is a little wonky around inheritance and
+    abbreviation preference. May need a bit more think. -->
+    <xsl:choose>
+      <xsl:when test="$meta.nodes[@name='productname']/d:productname/@version">
+        <!-- We should probably split the version attrib value? -->
+        <xsl:apply-templates select="$meta.nodes[@name='productname']/d:productname[1]/@version" />
+      </xsl:when>
+      <xsl:when test="$meta.nodes[@name='bugtracker']/d:phrase[@name='productnumber'] and $prefer-abbreviation = 0">
+        <xsl:apply-templates select="$meta.nodes[@name='bugtracker']/d:phrase[@name='productnumber'][last()]" mode="meta"/>
+      </xsl:when>
+      <xsl:when test="*/d:productnumber[@role='abbrev'] and $prefer-abbreviation = 1">
+        <xsl:apply-templates select="(*/d:productnumber[@role='abbrev'])[last()]"/>
+      </xsl:when>
+      <xsl:when test="*/d:productnumber[not(@role='abbrev')]">
+        <xsl:apply-templates select="(*/d:productnumber[not(@role='abbrev')])[last()]"/>
+      </xsl:when>
+      <xsl:when test="*/d:productnumber">
+        <xsl:apply-templates select="(*/d:productnumber)[last()]"/>
+      </xsl:when>
+      <xsl:when test="ancestor-or-self::*/*/d:productnumber[@role='abbrev'] and $prefer-abbreviation = 1">
+        <xsl:apply-templates select="(ancestor-or-self::*/*/d:productnumber[@role='abbrev'])[last()]"/>
+      </xsl:when>
+      <xsl:when test="ancestor-or-self::*/*/d:productnumber[not(@role='abbrev')]">
+        <xsl:apply-templates select="(ancestor-or-self::*/*/d:productnumber[not(@role='abbrev')])[last()]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="(ancestor-or-self::*/*/d:productnumber)[last()]"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+
+  <xsl:template name="version.info">
+    <xsl:param name="prefaced" select="0"/>
+    <xsl:param name="prefer-abbreviation" select="0"/>
+
+    <xsl:variable name="product-name">
+      <xsl:call-template name="product.name">
+        <xsl:with-param name="prefer-abbreviation" select="$prefer-abbreviation"/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="product-number">
+      <xsl:call-template name="product.number">
+        <xsl:with-param name="prefer-abbreviation" select="$prefer-abbreviation"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:if test="$prefaced = 1 and ($product-name != '' or $product-number != '')">
+      <xsl:call-template name="gentext">
+        <xsl:with-param name="key">version.info</xsl:with-param>
+      </xsl:call-template>
+      <xsl:text> </xsl:text>
+    </xsl:if>
+    <xsl:copy-of select="$product-name"/>
+    <xsl:if test="$product-name != '' and $product-number != ''">
+      <xsl:text> </xsl:text>
+    </xsl:if>
+    <xsl:copy-of select="$product-number"/>
+  </xsl:template>
+
+  <xsl:template name="version.info.headline">
+    <xsl:variable name="info-text">
+      <xsl:call-template name="version.info">
+        <xsl:with-param name="prefaced" select="0"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:if test="$generate.version.info != 0 and $info-text != ''">
+      <fo:block role="big-version-info"><xsl:copy-of select="$info-text"/></fo:block>
+    </xsl:if>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/trd/fo/param.xsl
+++ b/trd/fo/param.xsl
@@ -23,4 +23,7 @@
     <xsl:attribute name="text-align">left</xsl:attribute>
     <xsl:attribute name="font-weight">normal</xsl:attribute>
   </xsl:attribute-set>
+  
+  <!-- Create version information before title? -->
+  <xsl:param name="generate.version.info" select="1"/>
 </xsl:stylesheet>

--- a/trd/xhtml/article.titlepage.templates.xsl
+++ b/trd/xhtml/article.titlepage.templates.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet  version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:exsl="http://exslt.org/common"
+  xmlns="http://www.w3.org/1999/xhtml"
+  exclude-result-prefixes="exsl d">
+
+  <xsl:template match="d:meta[@name='category' or @name='type']" mode="article.titlepage.recto.auto.mode">
+    <xsl:apply-templates select="."/>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/trd/xhtml/docbook.xsl
+++ b/trd/xhtml/docbook.xsl
@@ -33,6 +33,7 @@
   <xsl:include href="../VERSION.xsl"/>
   <xsl:include href="param.xsl"/>
   <xsl:include href="../../sbp/xhtml/titlepage.templates.xsl"/>
+  <xsl:include href="article.titlepage.templates.xsl"/>
   <xsl:include href="book.titlepage.templates.xsl"/>
 
 </xsl:stylesheet>


### PR DESCRIPTION
* Change order of authors and platforms
* Add a bold, localized text "Authors" before the list of authors
* Disable the cover logo at the bottom
* For HTML, add `<meta name="type">` after series

I get:

<img width="776" height="975" alt="Bildschirmfoto_20260710_105735" src="https://github.com/user-attachments/assets/22939cc1-408b-4149-8806-7a204e56933b" />

----

For HTML:

<img width="933" height="335" alt="Bildschirmfoto_20260717_074855" src="https://github.com/user-attachments/assets/f0e98dc2-a428-4385-8a37-309212eeb732" />

