### PR TITLE
Add missing normalize-space for name key

### DIFF
--- a/suse2022-ns/xhtml/json-ld.xsl
+++ b/suse2022-ns/xhtml/json-ld.xsl
@@ -592,7 +592,7 @@
       </xsl:if>
     </xsl:variable>
     <xsl:text>"name": "</xsl:text>
-    <xsl:value-of select="$_name"/>
+    <xsl:value-of select="normalize-space($_name)"/>
     <xsl:text>",</xsl:text>
   </xsl:template>
 


### PR DESCRIPTION
The key "name" contains sometimes linebreaks. This is an invalid character in JSON-lD.