### PR TITLE
HTML: Check generate.revhistory for d:revhistory

### DIFF
--- a/suse2022-ns/xhtml/titlepage.xsl
+++ b/suse2022-ns/xhtml/titlepage.xsl
@@ -68,6 +68,7 @@
 <!-- ============================================================== -->
 <!-- revhistory handling -->
 <xsl:template match="d:revhistory" mode="titlepage.mode">
+  <xsl:if test="number($generate.revhistory) != 0">
     <xsl:variable name="revhistory.text">
       <xsl:call-template name="gentext">
         <xsl:with-param name="key" select="'RevHistory'" />
@@ -186,6 +187,7 @@
         <xsl:copy-of select="$contents" />
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:if>
 </xsl:template>
 
 


### PR DESCRIPTION
Thanks to Tanja, single HTML showed a link in the titlepage even if generate.revhistory was disabled (=0).

An additional `xsl:If` clause should avoid creating links or even separate `rh-*.html` files.